### PR TITLE
64 Global elevenlabs voice config overrides Wingman elevenlabs config | Breaks app

### DIFF
--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -74,10 +74,9 @@ edge_tts:
 # Note that elevenlabs requires an own API key. See https://elevenlabs.io/ for more information.
 # Also note: With elevenlabs you can't add audio effects right now. We are working on that.'
 elevenlabs:
-  voice: Adam # Simple voice names.
-  # If you have a custom voice, you can use the voice ID instead:
-  # voice:
-  #   id: xxx
+  voice:
+    name: Adam # Simple voice names. Only works with the "default" 11Labs voices.
+    #id: xxx   # Uncomment this if you want to use a voice from your VoiceLab. Overrules name if both are set!
   model: eleven_multilingual_v2 # or: 'eleven_turbo_v2' or 'eleven_multilingual_v1' or 'eleven_multilingual_v2'
   latency: 3 # 0 - 4
   voice_settings:
@@ -107,8 +106,6 @@ wingmen:
   #
   board-computer: # The internal name of the wingman. It doesn't really matter. Just has to be unique within this file.
     openai:
-      # You could require an alternative key, that differs from the one defined globally.
-      # required_key: openai-alternative
       #
       # The "context" for the wingman. Here's where you can tell the AI how to behave.
       # This is probably what you want to play around with the most.

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -1,6 +1,5 @@
 import json
 from elevenlabs import generate, stream, Voice, VoiceSettings, voices
-from exceptions import MissingApiKeyException
 from services.open_ai import OpenAi
 from services.edge import EdgeTTS
 from services.printr import Printr
@@ -47,6 +46,11 @@ class OpenAiWingman(Wingman):
         else:
             self.openai = OpenAi(openai_api_key)
 
+        self.__validate_elevenlabs_config(errors)
+
+        return errors
+
+    def __validate_elevenlabs_config(self, errors):
         if self.tts_provider == "elevenlabs":
             self.elevenlabs_api_key = self.secret_keeper.retrieve(
                 requester=self.name,
@@ -58,8 +62,26 @@ class OpenAiWingman(Wingman):
                 errors.append(
                     "Missing 'elevenlabs' API key. Please provide a valid key in the settings or use another tts_provider."
                 )
-
-        return errors
+                return
+            elevenlabs_settings = self.config.get("elevenlabs")
+            if not elevenlabs_settings:
+                errors.append(
+                    "Missing 'elevenlabs' section in config. Please provide a valid config or change the TTS provider."
+                )
+                return
+            if not elevenlabs_settings.get("model"):
+                errors.append("Missing 'model' setting in 'elevenlabs' config.")
+                return
+            voice_settings = elevenlabs_settings.get("voice")
+            if not voice_settings:
+                errors.append(
+                    "Missing 'voice' section in 'elevenlabs' config. Please provide a voice configuration as shown in our example config."
+                )
+                return
+            if not voice_settings.get("id") and not voice_settings.get("name"):
+                errors.append(
+                    "Missing 'id' or 'name' in 'voice' section of 'elevenlabs' config. Please provide a valid name or id for the voice in your config."
+                )
 
     async def _transcribe(self, audio_input_wav: str) -> tuple[str | None, str | None]:
         """Transcribes the recorded audio to text using the OpenAI Whisper API.
@@ -350,12 +372,19 @@ class OpenAiWingman(Wingman):
 
             self.audio_player.play("audio_output/edge_tts.mp3")
         elif self.tts_provider == "elevenlabs":
+            # already validated in validate():
             elevenlabs_config = self.config["elevenlabs"]
-            voice = elevenlabs_config.get("voice")
-            if not isinstance(voice, str):
-                voice = Voice(voice_id=voice.get("id"))
-            else:
-                voice = next((v for v in voices() if v.name == voice), None)
+            voice_config = elevenlabs_config["voice"]
+            # validate() already checked that at least one of these is set
+            voice_id = voice_config.get("id")
+            voice_name = voice_config.get("name")
+            voice = (
+                Voice(voice_id=voice_id)  # id takes precendence if set
+                if voice_id
+                else next(
+                    (v for v in voices() if v.name == voice_name), None
+                )  # else use the name
+            )
 
             voice_setting = self._get_elevenlabs_settings(elevenlabs_config)
             if voice_setting:


### PR DESCRIPTION
fixes https://github.com/ShipBit/wingman-ai/issues/64

The config structure was changed from:

```yaml
elevenlabs: Adam
   # id: xyz # if you want to use an id
```

to

```yaml
elevenlabs: 
   name: Adam
   id: xyz # if you want to use an id
```

The OpenAiWingman base now validates that either `voice.name` or `voice.id` are present in the config. 
If **both** are set, `id` takes precedence over `name.`