### PR TITLE
fix schema generation

### DIFF
--- a/api/interface.py
+++ b/api/interface.py
@@ -259,8 +259,14 @@ class NestedConfig(BaseModel):
 
 
 class WingmanConfig(NestedConfig):
-    class Config:  # allow extra fields that are not defined in the model here
-        extra = "allow"
+    def __getitem__(self, item):
+        return self.extra_properties.get(item)
+
+    def __setitem__(self, key, value):
+        self.extra_properties[key] = value
+
+    # these can only be strings because otherwise our schema generation will break (if they were of type Any)
+    custom_properties: Optional[dict[str, str]] = {}
 
     disabled: Optional[bool] = False
     custom_class: Optional[CustomWingmanClassConfig] = None

--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -517,7 +517,9 @@ wingmen:
     # A custom config entry that Wingman requires. Validate it in your code in the validate() method.
     # Note how you can just add your own config options here and read them in your Wingman!
     # Do not put API keys or other sensitive data here! Use the secret_keeper class for that.
-    starhead_api_url: https://api.star-head.de
+    # Note that the values can only be strings. You can convert them to other types in your code.
+    custom_properties:
+      starhead_api_url: https://api-test.star-head.de
 
     features:
       tts_provider: edge_tts

--- a/wingmen/star_head_wingman.py
+++ b/wingmen/star_head_wingman.py
@@ -47,8 +47,8 @@ class StarHeadWingman(OpenAiWingman):
         errors: list[str] = await super().validate()
 
         # add custom errors
-        if not self.config.starhead_api_url:
-            errors.append("Missing 'starhead_api_url' in config.yaml")
+        if not self.config.custom_properties["starhead_api_url"]:
+            errors.append("Missing custom property 'starhead_api_url' in config.yaml")
 
         try:
             self._prepare_data()
@@ -59,7 +59,7 @@ class StarHeadWingman(OpenAiWingman):
 
     def _prepare_data(self):
         # here validate() already ran, so we can safely access the config
-        self.star_head_url = self.config.starhead_api_url
+        self.star_head_url = self.config.custom_properties["starhead_api_url"]
 
         self.start_execution_benchmark()
 


### PR DESCRIPTION
BREAKING CHANGE: 
Custom Wingman now have to define custom config entries in `custom_properties`. These can only be strings, so if you want to use numbers etc. you have to parse them manually in your custom wingman. 

This change is required because otherwise our schema generation for the WingmanConfig class will break and just say it's a generic dictionary.