### PR TITLE
Change audio recorder to use 16000 sample rate

### DIFF
--- a/services/audio_recorder.py
+++ b/services/audio_recorder.py
@@ -15,7 +15,7 @@ class AudioRecorder(FileCreator):
     def __init__(
         self,
         app_root_dir: str,
-        samplerate: int = 44100,
+        samplerate: int = 16000,
         channels: int = 1,
     ):
         super().__init__(app_root_dir, RECORDING_PATH)


### PR DESCRIPTION
This enables easier use of a local whispercpp server should it ever be included within wingman itself or if a user wants to use a whispercpp server instead of using azure or openai paid cloud services (default whispercpp server only supports 16000 audio, though it will also autoconvert at the cost of increased latency) 

When making this change to other repos in the past I have seen no downsides. File size also remains smaller this way.