### PR TITLE
XVASynth TTS support

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from pydantic import BaseModel
 
 
@@ -59,6 +59,11 @@ class EdgeTtsVoiceGender(Enum):
     FEMALE = "Female"
 
 
+class XVASynthModel(StrEnum):
+    SYNTHESIZE_URL = "http://127.0.0.1:8008/synthesize"
+    LOADMODEL_URL = "http://127.0.0.1:8008/loadModel"
+
+
 class OpenAiModel(Enum):
     GPT_35_TURBO_1106 = "gpt-3.5-turbo-1106"
     GPT_4_1106_PREVIEW = "gpt-4-1106-preview"
@@ -87,6 +92,7 @@ class TtsProvider(Enum):
     ELEVENLABS = "elevenlabs"
     EDGE_TTS = "edge_tts"
     AZURE = "azure"
+    XVASYNTH = "xvasynth"
 
 
 class SttProvider(Enum):
@@ -142,6 +148,10 @@ class ElevenlabsModelEnumModel(BaseEnumModel):
     model: ElevenlabsModel
 
 
+class XVASynthModelEnumModel(BaseEnumModel):
+    model: XVASynthModel
+
+
 class EdgeTtsVoiceGenderEnumModel(BaseEnumModel):
     gender: EdgeTtsVoiceGender
 
@@ -186,6 +196,7 @@ ENUM_TYPES = {
     "CommandTag": CommandTagEnumModel,
     "AzureApiVersion": AzureApiVersionEnumModel,
     "ElevenlabsModel": ElevenlabsModelEnumModel,
+    "XVASynthModel": XVASynthModelEnumModel,
     "EdgeTtsVoiceGender": EdgeTtsVoiceGenderEnumModel,
     "OpenAiModel": OpenAiModelEnumModel,
     "OpenAiTtsVoice": OpenAiTtsVoiceEnumModel,

--- a/api/enums.py
+++ b/api/enums.py
@@ -59,11 +59,6 @@ class EdgeTtsVoiceGender(Enum):
     FEMALE = "Female"
 
 
-class XVASynthModel(StrEnum):
-    SYNTHESIZE_URL = "http://127.0.0.1:8008/synthesize"
-    LOADMODEL_URL = "http://127.0.0.1:8008/loadModel"
-
-
 class OpenAiModel(Enum):
     GPT_35_TURBO_1106 = "gpt-3.5-turbo-1106"
     GPT_4_1106_PREVIEW = "gpt-4-1106-preview"
@@ -148,10 +143,6 @@ class ElevenlabsModelEnumModel(BaseEnumModel):
     model: ElevenlabsModel
 
 
-class XVASynthModelEnumModel(BaseEnumModel):
-    model: XVASynthModel
-
-
 class EdgeTtsVoiceGenderEnumModel(BaseEnumModel):
     gender: EdgeTtsVoiceGender
 
@@ -196,7 +187,6 @@ ENUM_TYPES = {
     "CommandTag": CommandTagEnumModel,
     "AzureApiVersion": AzureApiVersionEnumModel,
     "ElevenlabsModel": ElevenlabsModelEnumModel,
-    "XVASynthModel": XVASynthModelEnumModel,
     "EdgeTtsVoiceGender": EdgeTtsVoiceGenderEnumModel,
     "OpenAiModel": OpenAiModelEnumModel,
     "OpenAiTtsVoice": OpenAiTtsVoiceEnumModel,

--- a/api/enums.py
+++ b/api/enums.py
@@ -1,4 +1,4 @@
-from enum import Enum, StrEnum
+from enum import Enum
 from pydantic import BaseModel
 
 

--- a/api/interface.py
+++ b/api/interface.py
@@ -160,6 +160,17 @@ class EdgeTtsConfig(BaseModel):
     gender: EdgeTtsVoiceGender
 
 
+class XVASynthTtsConfig(BaseModel):
+    xvasynth_path: str
+    game_folder_name: str
+    voice: str
+    language: Optional[str] = "en"
+    pace: Optional[float] = 1.0
+    useSR: Optional[bool] = False
+    useCleanup: Optional[bool] = False
+    process_device: Optional[str] = "cpu"
+
+
 class OpenAiConfig(BaseModel):
     context: Optional[str] = None
     """The "context" for the wingman. Here's where you can tell the AI how to behave.
@@ -262,6 +273,7 @@ class NestedConfig(BaseModel):
     openai: OpenAiConfig
     edge_tts: EdgeTtsConfig
     elevenlabs: ElevenlabsConfig
+    xvasynth: XVASynthTtsConfig
     azure: AzureConfig
     commands: list[CommandConfig] | None = None
 

--- a/api/interface.py
+++ b/api/interface.py
@@ -166,9 +166,11 @@ class XVASynthTtsConfig(BaseModel):
     voice: str
     language: Optional[str] = "en"
     pace: Optional[float] = 1.0
-    useSR: Optional[bool] = False
-    useCleanup: Optional[bool] = False
+    use_sr: Optional[bool] = False
+    use_cleanup: Optional[bool] = False
     process_device: Optional[str] = "cpu"
+    synthesize_url: Optional[str] = "http://127.0.0.1:8008/synthesize"
+    load_model_url: Optional[str] = "http://127.0.0.1:8008/loadModel"
 
 
 class OpenAiConfig(BaseModel):

--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -20,7 +20,7 @@ features:
   # ─────────────────────── TTS Provider ─────────────────────────
   # You can override the text-to-spech provider if your Wingman supports it. Our OpenAI wingman does!
   # Note that the other providers may have additional config blocks as shown below for edge_tts. These are only used if the provider is set here.
-  tts_provider: openai # available: openai, edge_tts, elevenlabs, azure
+  tts_provider: openai # available: openai, edge_tts, elevenlabs, azure, xvasynth
 
   # ─────────────────────── Speech to text Provider ─────────────────────────
   # You can override the speech to text provider to use a different one than the default.
@@ -157,11 +157,13 @@ azure:
 # The ideal setup is to start XVASynth and then run WingmanAI. However, if you do not do so, WingmanAI will try to run XVASynth if you use it for a wingman.
 # This implementation only supports XVASynth v3 voices.
 # You can find the voice folders you have installed in the /resources/app/models folder, and inside of each will be the voices.
-# An example below is where "terminator" is the name of the game folder inside of "models" and "tn-850" is the name of the voice.  The name of the voice is the name without the .pt or .json file extensions.
+# An example below is where "terminator" is the name of the game folder inside of "models" and "tn-850" is the name of the voice.  
+# The name of the voice is the name without the .pt or .json file extensions.
+# Only used if features > tts_provider is set to 'xvasynth' above.
 xvasynth:
   xvasynth_path: C:\Program Files (x86)\Steam\steamapps\common\xVASynth # The path to your install of XVASynth.  If you do not provide this and try to use xvasynth there will be an error.
   process_device: cpu # Can be cpu or gpu, if gpu you may need to take more steps to have xvasynth run on gpu.  Defaults to cpu.
-  game_folder_name: terminator #The game folder name of the voice you donwloaded to use as your primary xvasynth voice.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
+  game_folder_name: terminator # The game folder name of the voice you donwloaded to use as your primary xvasynth voice.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
   voice: tn-T850 # The name of the voice you downloaded to use.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
   language: en # The language the voice will speak in. Some XVASynth voices are trained to be multi-lingual.  Defaults to english, 'en'.
   pace: 1.0 # The speed of the voice playback. Defaults to 1.0.

--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -156,8 +156,8 @@ azure:
 # You can find the program here: https://store.steampowered.com/app/1765720/xVASynth/
 # The ideal setup is to start XVASynth and then run WingmanAI. However, if you do not do so, WingmanAI will try to run XVASynth if you use it for a wingman.
 # This implementation only supports XVASynth v3 voices.
-# You can find the voice folders you have installed in the /resources/app/models folder, and inside of each will be the voices.
-# An example below is where "terminator" is the name of the game folder inside of "models" and "tn-850" is the name of the voice.  
+# You can find the voice folders you have installed in the [your xVASynth directory]/resources/app/models folder, and inside of each will be the voices.
+# An example below is where "terminator" is the name of the game folder inside of "models" and "tn-850" is the name of the voice.
 # The name of the voice is the name without the .pt or .json file extensions.
 # Only used if features > tts_provider is set to 'xvasynth' above.
 xvasynth:
@@ -167,8 +167,10 @@ xvasynth:
   voice: tn-T850 # The name of the voice you downloaded to use.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
   language: en # The language the voice will speak in. Some XVASynth voices are trained to be multi-lingual.  Defaults to english, 'en'.
   pace: 1.0 # The speed of the voice playback. Defaults to 1.0.
-  useSR: false # Whether to use XVASynth's super resolution mode.  Will take longer and generally not recommended.  Defaults to false.
-  useCleanup: false # Whether to use XVASynth's cleanup mode.  May make voice quality better or worse depending on the voice model.  Defaults to false.
+  use_sr: false # Whether to use XVASynth's super resolution mode.  Will take longer and generally not recommended.  Defaults to false.
+  use_cleanup: false # Whether to use XVASynth's cleanup mode.  May make voice quality better or worse depending on the voice model.  Defaults to false.
+  synthesize_url: http://127.0.0.1:8008/synthesize # This should typically be left alone, changing it will cause errors unless you manually changed xvasynth's server
+  load_model_url: http://127.0.0.1:8008/loadModel # This should be typically left alone, changing it will cause errors unless you manually changed xvasynth's server
 # ────────────────────────────── GLOBAL COMMANDS ───────────────────────────────
 # You can use these in all wingmen and you can put your own here, too.
 commands:

--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -151,6 +151,22 @@ azure:
       - en-US
       - de-DE
 
+# ────────────────────────────────── XVASYNTH ────────────────────────────────────
+# XVASynth is a free program on Steam that uses your local computer resources to generate text to speech using free voice models created by the community.
+# You can find the program here: https://store.steampowered.com/app/1765720/xVASynth/
+# The ideal setup is to start XVASynth and then run WingmanAI. However, if you do not do so, WingmanAI will try to run XVASynth if you use it for a wingman.
+# This implementation only supports XVASynth v3 voices.
+# You can find the voice folders you have installed in the /resources/app/models folder, and inside of each will be the voices.
+# An example below is where "terminator" is the name of the game folder inside of "models" and "tn-850" is the name of the voice.  The name of the voice is the name without the .pt or .json file extensions.
+xvasynth:
+  xvasynth_path: C:\Program Files (x86)\Steam\steamapps\common\xVASynth # The path to your install of XVASynth.  If you do not provide this and try to use xvasynth there will be an error.
+  process_device: cpu # Can be cpu or gpu, if gpu you may need to take more steps to have xvasynth run on gpu.  Defaults to cpu.
+  game_folder_name: terminator #The game folder name of the voice you donwloaded to use as your primary xvasynth voice.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
+  voice: tn-T850 # The name of the voice you downloaded to use.  This can be overwritten in a particular wingman.  If you do not provide this and try to use xvasynth there will be an error.
+  language: en # The language the voice will speak in. Some XVASynth voices are trained to be multi-lingual.  Defaults to english, 'en'.
+  pace: 1.0 # The speed of the voice playback. Defaults to 1.0.
+  useSR: false # Whether to use XVASynth's super resolution mode.  Will take longer and generally not recommended.  Defaults to false.
+  useCleanup: false # Whether to use XVASynth's cleanup mode.  May make voice quality better or worse depending on the voice model.  Defaults to false.
 # ────────────────────────────── GLOBAL COMMANDS ───────────────────────────────
 # You can use these in all wingmen and you can put your own here, too.
 commands:

--- a/providers/xvasynth.py
+++ b/providers/xvasynth.py
@@ -57,10 +57,9 @@ class XVASynth:
     def play_audio(
         self, text: str, config: XVASynthTtsConfig, sound_config: SoundConfig
     ):
-        if config.voice != self.current_voice:
-            load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language)
-            if load_ok != "ok":
-                print("There was a problem loading your XVASynth voice, check your voice name and game folder for your voice in XVAsynth")
+        load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language)
+        if load_ok != "ok":
+            print("There was a problem loading your XVASynth voice, check your voice name and game folder for your voice in XVAsynth")
         voiceline = text
         file_dir = path.abspath(path.dirname(__file__))
         wingman_dir = path.abspath(path.dirname(file_dir))

--- a/providers/xvasynth.py
+++ b/providers/xvasynth.py
@@ -1,0 +1,108 @@
+import requests
+import json
+import os
+import subprocess
+import time
+from api.enums import XVASynthModel
+from api.interface import XVASynthTtsConfig, SoundConfig
+from services.audio_player import AudioPlayer
+from os import path
+
+class XVASynth:
+    def __init__(self, wingman_name: str, xvasynth_path: str, process_device: str, times_checked_xvasynth: int):
+        self.wingman_name = wingman_name if wingman_name else ""
+        self.xvasynth_path = ""
+        self.process_device = ""
+        self.times_checked_xvasynth = 0
+        
+    def validate_config(self, config: XVASynthTtsConfig, errors: list[str]):
+        if not errors:
+            errors = []
+
+        if not config.xvasynth_path:
+            errors.append(
+                "Missing path to xvasynth on user's hard drive. Please provide a valid path to use xvasynth."
+            )
+        if not config.game_folder_name:
+            errors.append(
+                "Missing game folder name where xvasynth voice is located, e.g., masseffect, skyrim, etc. Please provide the game folder name to use xvasynth voice."
+            )
+        if not config.voice:
+            errors.append(
+                "Missing voice name.  Please provide voice name to use xvasynth."
+            )
+            
+        self.xvasynth_path = config.xvasynth_path
+        self.process_device = config.process_device
+        self.times_checked_xvasynth = 0
+        # check if xvasynth is running a few times, if cannot find it, send error
+        while self.times_checked_xvasynth < 5:
+            check = self.check_if_xvasynth_is_running()
+            if check == "ok":
+                break
+            self.times_checked_xvasynth+=1
+        
+        if check != "ok":
+            errors.append(check)
+        # if xvasynth is found, load initial XVASynth voice
+        else:
+            loadmodel_url = XVASynthModel.LOADMODEL_URL
+            # example: voice_path = "D:\\DExtraSteamGames\\steamapps\\common\\xVASynth\\resources\\app\\models\\masseffect\\me_edi"
+            voice_path = config.xvasynth_path + "\\resources\\app\\models\\" + config.game_folder_name + "\\" + config.voice
+            base_lang = config.language
+            model_change = {
+            'outputs': None,
+            'version': '3.0',
+            'model': voice_path, 
+            'modelType': 'XVAPitch',
+            'base_lang': base_lang, 
+            'pluginsContext': '{}',
+            }
+            requests.post(loadmodel_url, json=model_change)
+        return errors
+
+    def play_audio(
+        self, text: str, config: XVASynthTtsConfig, sound_config: SoundConfig
+    ):
+        #voice = config.voice
+        voiceline = text
+        file_dir = path.abspath(path.dirname(__file__))
+        wingman_dir = path.abspath(path.dirname(file_dir))
+        final_voiceline_file =  wingman_dir + "\\audio_output\\xvasynth.wav"
+
+        if path.exists(final_voiceline_file):
+            os.remove(final_voiceline_file)
+
+        # Synthesize voiceline
+        synthesize_url= XVASynthModel.SYNTHESIZE_URL
+        data = {
+            'pluginsContext': '{}',
+            'modelType': 'xVAPitch',
+            'sequence': voiceline,
+            'pace': config.pace,
+            'outfile': final_voiceline_file,
+            'vocoder': 'n/a',
+            'base_lang': config.language,
+            'base_emb': '[]',
+            'useSR': config.useSR,
+            'useCleanup': config.useCleanup,
+        }
+        response = requests.post(synthesize_url, json=data)
+        audio_player = AudioPlayer()
+        audio, sample_rate = audio_player.get_audio_from_file(final_voiceline_file)
+        audio_player.stream_with_effects(input_data=(audio, sample_rate), config=sound_config)
+
+    def check_if_xvasynth_is_running(self):
+        try:
+            response = requests.get('http://127.0.0.1:8008/')
+            response.raise_for_status()
+
+        except requests.RequestException as e:
+            time.sleep(1)
+            if self.times_checked_xvasynth == 1:
+                #If not found, try to start xvasynth as a subprocess
+                subprocess.Popen([f'{self.xvasynth_path}/resources/app/cpython_{self.process_device}/server.exe'], cwd=self.xvasynth_path)
+                time.sleep(6)
+            return "ERROR: You chose XVASynth for Text to Speech but the program does not appear to be running.  Please start XVASynth and try again or choose another Text to Speech type."
+
+        return "ok"

--- a/providers/xvasynth.py
+++ b/providers/xvasynth.py
@@ -3,10 +3,11 @@ import json
 import os
 import subprocess
 import time
-from api.enums import XVASynthModel
-from api.interface import XVASynthTtsConfig, SoundConfig
+from api.enums import WingmanInitializationErrorType
+from api.interface import XVASynthTtsConfig, SoundConfig, WingmanInitializationError
 from services.audio_player import AudioPlayer
 from os import path
+from urllib.parse import urlparse, urlunparse
 
 class XVASynth:
     def __init__(self, wingman_name: str, xvasynth_path: str, process_device: str, times_checked_xvasynth: int):
@@ -16,21 +17,33 @@ class XVASynth:
         self.times_checked_xvasynth = 0
         self.current_voice = ""
         
-    def validate_config(self, config: XVASynthTtsConfig, errors: list[str]):
+    def validate_config(self, config: XVASynthTtsConfig, errors: list[WingmanInitializationError]):
         if not errors:
             errors = []
 
         if not config.xvasynth_path:
             errors.append(
-                "Missing path to xvasynth on user's hard drive. Please provide a valid path to use xvasynth."
+                WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message="Missing path to xvasynth on user's hard drive. Please provide a valid path to use xvasynth.",
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                )
             )
         if not config.game_folder_name:
             errors.append(
-                "Missing game folder name where xvasynth voice is located, e.g., masseffect, skyrim, etc. Please provide the game folder name to use xvasynth voice."
+                WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message="Missing game folder name where xvasynth voice is located, e.g., masseffect, skyrim, etc. Please provide the game folder name to use xvasynth voice.",
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                )
             )
         if not config.voice:
             errors.append(
-                "Missing voice name.  Please provide voice name to use xvasynth."
+                WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message="Missing voice name.  Please provide voice name to use xvasynth.",
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                )
             )
             
         self.xvasynth_path = config.xvasynth_path
@@ -38,18 +51,26 @@ class XVASynth:
         self.times_checked_xvasynth = 0
         # check if xvasynth is running a few times, if cannot find it, send error
         while self.times_checked_xvasynth < 5:
-            check = self.check_if_xvasynth_is_running()
+            check = self.check_if_xvasynth_is_running(config.synthesize_url)
             if check == "ok":
                 break
             self.times_checked_xvasynth+=1
         
         if check != "ok":
-            errors.append(check)
+            errors.append(WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message=check,
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                ))
         # if xvasynth is found, load initial XVASynth voice
         else:
-            load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language)
+            load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language, load_model_url=config.load_model_url)
             if load_ok != "ok":
-                errors.append(load_ok)
+                errors.append(WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message=load_ok,
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                ))
             self.current_voice = config.voice
 
         return errors
@@ -57,7 +78,7 @@ class XVASynth:
     def play_audio(
         self, text: str, config: XVASynthTtsConfig, sound_config: SoundConfig
     ):
-        load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language)
+        load_ok = self.load_xvasynth_model(path_to_xvasynth=config.xvasynth_path, game_folder=config.game_folder_name, voice=config.voice, language=config.language, load_model_url=config.load_model_url)
         if load_ok != "ok":
             print("There was a problem loading your XVASynth voice, check your voice name and game folder for your voice in XVAsynth")
         voiceline = text
@@ -69,7 +90,7 @@ class XVASynth:
             os.remove(final_voiceline_file)
 
         # Synthesize voiceline
-        synthesize_url= XVASynthModel.SYNTHESIZE_URL
+        synthesize_url= config.synthesize_url
         data = {
             'pluginsContext': '{}',
             'modelType': 'xVAPitch',
@@ -79,17 +100,20 @@ class XVASynth:
             'vocoder': 'n/a',
             'base_lang': config.language,
             'base_emb': '[]',
-            'useSR': config.useSR,
-            'useCleanup': config.useCleanup,
+            'useSR': config.use_sr,
+            'useCleanup': config.use_cleanup,
         }
         response = requests.post(synthesize_url, json=data)
         audio_player = AudioPlayer()
         audio, sample_rate = audio_player.get_audio_from_file(final_voiceline_file)
         audio_player.stream_with_effects(input_data=(audio, sample_rate), config=sound_config)
 
-    def check_if_xvasynth_is_running(self):
+    def check_if_xvasynth_is_running(self, url:str):
+        # get base url from synthesize url in config
+        parsed_url = urlparse(url)
+        base_url = urlunparse((parsed_url.scheme, parsed_url.netloc, '/', '', '', ''))
         try:
-            response = requests.get('http://127.0.0.1:8008/')
+            response = requests.get(base_url)
             response.raise_for_status()
 
         except requests.RequestException as e:
@@ -102,8 +126,7 @@ class XVASynth:
 
         return "ok"
 
-    def load_xvasynth_model(self, path_to_xvasynth:str, game_folder:str, voice:str, language:str):
-        loadmodel_url = XVASynthModel.LOADMODEL_URL
+    def load_xvasynth_model(self, path_to_xvasynth:str, game_folder:str, voice:str, language:str, load_model_url:str):
         # example: voice_path = "D:\\DExtraSteamGames\\steamapps\\common\\xVASynth\\resources\\app\\models\\masseffect\\me_edi"
         voice_path = path_to_xvasynth + "\\resources\\app\\models\\" + game_folder + "\\" + voice
         base_lang = language
@@ -116,7 +139,7 @@ class XVASynth:
             'pluginsContext': '{}',
             }
         try:
-            response = requests.post(loadmodel_url, json=model_change)
+            response = requests.post(load_model_url, json=model_change)
             response.raise_for_status()
             self.current_voice = voice
             return "ok"

--- a/services/config_manager.py
+++ b/services/config_manager.py
@@ -150,7 +150,7 @@ class ConfigManager:
         # Start with a copy of the wingman's specific config to keep it intact.
         merged = wingman.copy()
         # Update 'openai', 'features', and 'edge_tts' sections from general config into wingman's config.
-        for key in ["sound", "openai", "features", "edge_tts", "elevenlabs", "azure"]:
+        for key in ["sound", "openai", "features", "edge_tts", "elevenlabs", "azure", "xvasynth"]:
             if key in general:
                 # Use copy.deepcopy to ensure a full deep copy is made and original is untouched.
                 merged[key] = self.__deep_merge(

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -68,6 +68,8 @@ class OpenAiWingman(Wingman):
 
         if self.uses_provider("elevenlabs"):
             await self.validate_and_set_elevenlabs(errors)
+        if self.uses_provider("xvasynth"):
+            await self.validate_and_set_xvasynth(errors)
 
         await self.validate_and_set_azure(errors)
 


### PR DESCRIPTION
Add support for XVASynth, a free program on steam for which people have trained and shared various voices from video games, as a Wingman TTS provider.

https://github.com/ShipBit/wingman-ai/assets/87204721/cca8686d-2fb2-4bf6-bbbb-28fc4865f1f9

V3 voices are supported in this implementation.  This PR allows the setting of global settings for xvasynth as a tts provider or to override those settings on a wingman-by-wingman basis like other speech providers. So you could have one xvasynth voice for one wingman and a different xvasynth voice for another.

Ideally the user starts XVASynth before starting wingman ai if they intend to use the program, but if they fail to do so, wingmanai will try to start xvasynth at the path the user has provided for the program.

I'm not sure whether xvasynth works with MacOS, so aside from any other issues you may have with this PR I know that could be a dealbreaker.  Even if this PR is not ultimately accepted, I felt it would be good to provide the code in case other developers in the future would like to see how to use XVASynth voices.

Generally speaking, quality will be below 11labs quality, but generally low on resource use and free, and more variety of voices available than other free options.  So, it may be a good balance for users.  Plus, since it was designed for video games there is a chance the user's video game may have pre-trained voices available.  For instance, Starfield XVASynth voices have been trained and are available here: https://www.nexusmods.com/starfield/mods/53?tab=files.  