### PR TITLE
New input functionality misc fixes

### DIFF
--- a/configs/system/config.example.yaml
+++ b/configs/system/config.example.yaml
@@ -473,7 +473,7 @@ wingmen:
         keys:
           - key: "~"
             modifier: shift
-            write: r_DisplayInfo # For now this will actually type all in lower case, the write command writes text to the screen in the position of your current cursor
+            write: r_DisplayInfo 2
             wait: 1
           - key: enter
             wait: 1
@@ -515,7 +515,7 @@ wingmen:
       # ───────────────────────────────────────────
       - name: LaunchMissile
         keys:
-          - key: middle
+          - key: primary
             hold: 1.0
         instant_activation:
           - Launch Missile
@@ -538,14 +538,14 @@ wingmen:
       - name: MoveTurretUp
         keys:
           - key: primary
-            moveto_relative: [0, 100]
+            moveto_relative: [0, -100]
         instant_activation:
           - Turret up
       # ───────────────────────────────────────────
-      - name: MoveTurretUp
+      - name: MoveTurretDown
         keys:
           - key: primary
-            moveto_relative: [0, -100]
+            moveto_relative: [0, 100]
         instant_activation:
           - Turret down
       # ───────────────────────── HOW TO INSERT NEW COMMANDS: ───────────────────────────

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -386,10 +386,14 @@ class Wingman(FileCreator):
             if key_cfg.moveto:
                 x,y = key_cfg.moveto
                 key_module.moveTo(x,y)
-
+            
+            # Normally would use key_module.move(x,y,duration) but for some reason this seems broken on pydirectinput-rgx, so computing the relative position manually and using move absolute instead.
             if key_cfg.moveto_relative:
                 x,y = key_cfg.moveto_relative
-                key_module.move(x,y)
+                oldx, oldy = key_module.position()
+                x = oldx + x
+                y = oldy + y
+                key_module.moveTo(x,y, duration=0.5)
 
             if key_cfg.key == "scroll":
                 if key_cfg.scroll_amount:
@@ -419,11 +423,12 @@ class Wingman(FileCreator):
                 for mod in reversed(modifiers):
                     key_module.keyUp(mod)
 
+            # Pyautogui automatically detects if the indicated keys need a "shift" applied; pydirectinput / pydirectinput-rgx do not. Pydirectinput-rgx implements a flavor of this with an auto_shift parameter that is not in pyautogui.
             if key_cfg.write:
-                key_module.typewrite(key_cfg.write, interval=0.10)
-
-            if key_cfg.write:
-                key_module.typewrite(key_cfg.write, interval=0.10)
+                try:
+                    key_module.write(key_cfg.write, interval=0.10, auto_shift=True)
+                except:
+                    key_module.write(key_cfg.write, interval=0.10)
 
             if key_cfg.wait:
                 time.sleep(key_cfg.wait)

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -422,5 +422,8 @@ class Wingman(FileCreator):
             if key_cfg.write:
                 key_module.typewrite(key_cfg.write, interval=0.10)
 
+            if key_cfg.write:
+                key_module.typewrite(key_cfg.write, interval=0.10)
+
             if key_cfg.wait:
                 time.sleep(key_cfg.wait)


### PR DESCRIPTION
-more testing revealed mouse relative input was not working as expected on windows. Changed to manually computing relative position and moving mouse instead

-further documentation review revealed how to get write function to work properly on windows to type capital letters and special characters, before it would only type lower case

-fixed some of the sample commands based on a community member's input (missile command and most used debug display info command) and also fixed typos in same (Turret Up/Down)