### PR TITLE
Prevent message history corruption and other small fixes

### DIFF
--- a/api/interface.py
+++ b/api/interface.py
@@ -238,8 +238,8 @@ class KeyPressConfig(BaseModel):
     modifier: Optional[str] = None
     """This will press "modifier + key" instead of just "modifier". Optional."""
 
-    wait: Optional[int] = None
-    """Wait n second before pressing the next key. Optional."""
+    wait: Optional[float] = None
+    """Wait time in seconds before pressing the next key. Optional."""
 
     hold: Optional[float] = None
     """The duration the key will be pressed in seconds. Optional."""

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -213,12 +213,13 @@ class Wingman(FileCreator):
                 self.print_execution_time(reset_timer=True)
 
             actual_response = instant_response or process_result
-            printr.print(
-                f"{actual_response}",
-                color=LogType.POSITIVE,
-                source=LogSource.WINGMAN,
-                source_name=self.name,
-            )
+            if actual_response:
+                printr.print(
+                    f"{actual_response}",
+                    color=LogType.POSITIVE,
+                    source=LogSource.WINGMAN,
+                    source_name=self.name,
+                )
 
         if self.debug:
             printr.print("Playing response back to user...", color=LogType.INFO)


### PR DESCRIPTION
Fixes:
- create dummy tool responses that get updates throughout the process to prevent history corruption
- automated message rearrangement if all tool calls are finished and message is no longer the newest one (this way the summarize gpt call will summarize the correct request)
- discard gpt calls if a new one started before it finished to prevent doubled tool calls / actions
- change config wait time type from int to float
- fix remember messages to retain the actual configured amount (was always one to many)
- Prevent "None" responses getting printed out