### PR TITLE
revert remember messages count fix, as incorrect and causing issues

### DIFF
--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -391,7 +391,7 @@ class OpenAiWingman(Wingman):
 
     def _cleanup_conversation_history(self):
         """Cleans up the conversation history by removing messages that are too old."""
-        remember_messages = self.config.features.remember_messages - 1
+        remember_messages = self.config.features.remember_messages
 
         if remember_messages is None or len(self.messages) == 0:
             return 0  # Configuration not set, nothing to delete.


### PR DESCRIPTION
fix:
- revert remember messages count fix, as incorrect and causing issues when `remember_messages` is not set at all.

Did an oopsie there yesterday.
The function actually worked as expected, I just checked at the wrong "time" in the code yesterday.
Apart from that, this "fix" was also causing issues, if this was not set in the config, because the substraction happened before the check if it is a None-type.

So please merge this to get rid of this small change from yesterday :)