### PR TITLE
update pydirectinput-rgx to version 2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ packaging~=23.2
 pedalboard~=0.8.7
 PyAutoGUI~=0.9.54
 pydantic~=2.5.3
-pydirectinput-rgx==2.1.0
+pydirectinput-rgx==2.1.1
 pyinstaller==6.3.0
 pynput~=1.7.6
 PyYAML~=6.0.1

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -387,14 +387,10 @@ class Wingman(FileCreator):
             if key_cfg.moveto:
                 x,y = key_cfg.moveto
                 key_module.moveTo(x,y)
-            
-            # Normally would use key_module.move(x,y,duration) but for some reason this seems broken on pydirectinput-rgx, so computing the relative position manually and using move absolute instead.
+
             if key_cfg.moveto_relative:
                 x,y = key_cfg.moveto_relative
-                oldx, oldy = key_module.position()
-                x = oldx + x
-                y = oldy + y
-                key_module.moveTo(x,y, duration=0.5)
+                key_module.move(x,y, duration=0.5)
 
             if key_cfg.key == "scroll":
                 if key_cfg.scroll_amount:


### PR DESCRIPTION
fixes bug with relative mouse movement, so revert back to key_module.move() function for relative mouse movement commands.