### PR TITLE
Whispercpp stt provider support

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -94,6 +94,7 @@ class SttProvider(Enum):
     OPENAI = "openai"
     AZURE = "azure"
     AZURE_SPEECH = "azure_speech"
+    WHISPERCPP = "whispercpp"
 
 
 class ConversationProvider(Enum):

--- a/api/interface.py
+++ b/api/interface.py
@@ -101,11 +101,14 @@ class AudioSettings(BaseModel):
     output: Optional[int] = None
 
 
+class WhispercppAutostartSettingsConfig(BaseModel):
+    whispercpp_exe_path: Optional[str] = None
+    whispercpp_model_path: Optional[str] = None
+
 class WhispercppSttConfig(BaseModel):
     base_url: str
     autostart: bool
-    whispercpp_exe_path: Optional[str] = None
-    whispercpp_model_path: Optional[str] = None
+    autostart_settings: WhispercppAutostartSettingsConfig
     temperature: float
     language: str
 

--- a/api/interface.py
+++ b/api/interface.py
@@ -105,6 +105,7 @@ class WhispercppAutostartSettingsConfig(BaseModel):
     whispercpp_exe_path: str
     whispercpp_model_path: str
 
+
 class WhispercppSttConfig(BaseModel):
     base_url: str
     autostart: bool
@@ -112,9 +113,11 @@ class WhispercppSttConfig(BaseModel):
     temperature: float
     language: str
 
+
 class WhispercppTranscript(BaseModel):
     text: str
     language: str
+
 
 class AzureInstanceConfig(BaseModel):
     api_base_url: str
@@ -201,6 +204,7 @@ class EdgeTtsConfig(BaseModel):
 
     Voice samples: https://speech.microsoft.com/portal/voicegallery
     """
+
 
 class XVASynthTtsConfig(BaseModel):
     xvasynth_path: str

--- a/api/interface.py
+++ b/api/interface.py
@@ -111,6 +111,8 @@ class WhispercppSttConfig(BaseModel):
 
 class WhispercppTranscript(BaseModel):
     text: str
+    language: str
+
 class AzureInstanceConfig(BaseModel):
     api_base_url: str
     """https://xxx.openai.azure.com/"""

--- a/api/interface.py
+++ b/api/interface.py
@@ -102,13 +102,13 @@ class AudioSettings(BaseModel):
 
 
 class WhispercppAutostartSettingsConfig(BaseModel):
-    whispercpp_exe_path: Optional[str] = None
-    whispercpp_model_path: Optional[str] = None
+    whispercpp_exe_path: str
+    whispercpp_model_path: str
 
 class WhispercppSttConfig(BaseModel):
     base_url: str
     autostart: bool
-    autostart_settings: WhispercppAutostartSettingsConfig
+    autostart_settings: Optional[WhispercppAutostartSettingsConfig] = None
     temperature: float
     language: str
 

--- a/api/interface.py
+++ b/api/interface.py
@@ -101,6 +101,16 @@ class AudioSettings(BaseModel):
     output: Optional[int] = None
 
 
+class WhispercppSttConfig(BaseModel):
+    base_url: Optional[str] = "http://127.0.0.1:8080"
+    autostart: Optional[bool] = False
+    whispercpp_exe_path: Optional[str] = None
+    whispercpp_model_path: Optional[str] = None
+    temperature: Optional[float] = 0.0
+    language: Optional[str] = "en"
+
+class WhispercppTranscript(BaseModel):
+    text: str
 class AzureInstanceConfig(BaseModel):
     api_base_url: str
     """https://xxx.openai.azure.com/"""
@@ -186,7 +196,6 @@ class EdgeTtsConfig(BaseModel):
 
     Voice samples: https://speech.microsoft.com/portal/voicegallery
     """
-
 
 class XVASynthTtsConfig(BaseModel):
     xvasynth_path: str
@@ -356,6 +365,7 @@ class NestedConfig(BaseModel):
     elevenlabs: ElevenlabsConfig
     azure: AzureConfig
     xvasynth: XVASynthTtsConfig
+    whispercpp: WhispercppSttConfig
     commands: Optional[list[CommandConfig]] = None
 
 

--- a/api/interface.py
+++ b/api/interface.py
@@ -102,12 +102,12 @@ class AudioSettings(BaseModel):
 
 
 class WhispercppSttConfig(BaseModel):
-    base_url: Optional[str] = "http://127.0.0.1:8080"
-    autostart: Optional[bool] = False
+    base_url: str
+    autostart: bool
     whispercpp_exe_path: Optional[str] = None
     whispercpp_model_path: Optional[str] = None
-    temperature: Optional[float] = 0.0
-    language: Optional[str] = "en"
+    temperature: float
+    language: str
 
 class WhispercppTranscript(BaseModel):
     text: str

--- a/configs/templates/defaults.yaml
+++ b/configs/templates/defaults.yaml
@@ -155,8 +155,9 @@ azure:
 whispercpp:
     base_url: http://127.0.0.1:8080 # This is the default for whispercpp, though you can change the host and port manually when launching your server with command line arguments.
     autostart: false # Set this to true if you want to set paths to your whispercpp server.exe and model bin below and have wingman try to launch whispercpp server itself.
-    whispercpp_exe_path: C:\Whispercpp\server.exe # This is just an example, you will insert here the full path to your whispercpp server.exe file.  Only used if autostart is set to true.
-    whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin # This is just an example, you will insert here the full path to the whispercpp ggml model file you downloaded.  Only used if autostart is set to true.
+    autostart_settings:
+        whispercpp_exe_path: C:\Whispercpp\server.exe # This is just an example, you will insert here the full path to your whispercpp server.exe file.  Only used if autostart is set to true.
+        whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin # This is just an example, you will insert here the full path to the whispercpp ggml model file you downloaded.  Only used if autostart is set to true.
     temperature: 0.0 # Not typically changed, but you can review the whispercpp documentation to determine whether to experiment with this value.
     language: en # Insert the whispercpp two letter code for your language if you intend to speak in another language.  Also make sure you do not use a english only whispercpp model if this is not set for en.
 

--- a/configs/templates/defaults.yaml
+++ b/configs/templates/defaults.yaml
@@ -148,14 +148,14 @@ azure:
 # There are executables for windows and mac, and for windows there are executables for just running on cpu (whisper-blas-bin) and Nvidia GPU (whisper-cublas)
 # The typical model used for multilingual is ggml-small.bin or ggml-base.bin. The typical model used for English only is ggml-base.en.bin.
 # The ideal setup is to start Whispercpp's server.exe file following its instructions and then run WingmanAI. 
-# However, if you want, you can set autostart: True and provide a path to your whispercpp server.exe and model .bin in the config below and wingmanai can try to start it for you.
+# However, if you want, you can set autostart: True and provide a path to your whispercpp server.exe and model .bin in the config below and wingmanai can try to start it for you.  Autostart currently works on Windows only.
 # You can expect quality to be worse than openai or azure whisper, but this method is free and may also be better for people with worse internet.  Speed will depend on your system resources.
 # Note that WingmanAI's support of whispercpp assumes you already know how to use the program.  It is just a connector.  If there are any issues with whispercpp you should direct them to the creator of whispercpp.
 # Only used if features > stt_provider is set to 'whispercpp' above.
 whispercpp:
     base_url: http://127.0.0.1:8080 # This is the default for whispercpp, though you can change the host and port manually when launching your server with command line arguments.
-    autostart: false # Set this to true if you want to set paths to your whispercpp server.exe and model bin below and have wingman try to launch whispercpp server itself.
-    autostart_settings:
+    autostart: false # Autostart currently works on Windows only.  Set this to true if you want to set paths to your whispercpp server.exe and model bin below and have wingman try to launch whispercpp server itself.
+    autostart_settings: # Required if autostart: true
         whispercpp_exe_path: C:\Whispercpp\server.exe # This is just an example, you will insert here the full path to your whispercpp server.exe file.  Only used if autostart is set to true.
         whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin # This is just an example, you will insert here the full path to the whispercpp ggml model file you downloaded.  Only used if autostart is set to true.
     temperature: 0.0 # Not typically changed, but you can review the whispercpp documentation to determine whether to experiment with this value.

--- a/configs/templates/defaults.yaml
+++ b/configs/templates/defaults.yaml
@@ -26,7 +26,7 @@ features:
   # ─────────────────────── Speech to text Provider ─────────────────────────
   # You can override the speech to text provider to use a different one than the default.
   # Note that the other providers may have additional config blocks as shown below for edge_tts. These are only used if the provider is set here.
-  stt_provider: azure_speech # available: openai, azure, azure_speech
+  stt_provider: azure_speech # available: openai, azure, azure_speech, whispercpp
 
   # ─────────────────────── Conversation Provider ─────────────────────────
   # You can override the conversation provider to use a different one than the default.

--- a/configs/templates/defaults.yaml
+++ b/configs/templates/defaults.yaml
@@ -141,6 +141,25 @@ azure:
     languages:
       - en-US
 
+# ────────────────────────────────── WHISPERCPP ────────────────────────────────────
+# Whispercpp is a free, open source, MIT-licensed program on Github that uses your local computer resources to generate speech to text using free models from whisper.
+# You can find the program here: https://github.com/ggerganov/whisper.cpp with downloadable .zip file releases for executables for your system here: https://github.com/ggerganov/whisper.cpp/releases
+# Models to use with whispercpp are available here: https://huggingface.co/ggerganov/whisper.cpp/tree/main and also the ggml versions of distil-whisper models here: https://huggingface.co/collections/distil-whisper/distil-whisper-models-65411987e6727569748d2eb6
+# There are executables for windows and mac, and for windows there are executables for just running on cpu (whisper-blas-bin) and Nvidia GPU (whisper-cublas)
+# The typical model used for multilingual is ggml-small.bin or ggml-base.bin. The typical model used for English only is ggml-base.en.bin.
+# The ideal setup is to start Whispercpp's server.exe file following its instructions and then run WingmanAI. 
+# However, if you want, you can set autostart: True and provide a path to your whispercpp server.exe and model .bin in the config below and wingmanai can try to start it for you.
+# You can expect quality to be worse than openai or azure whisper, but this method is free and may also be better for people with worse internet.  Speed will depend on your system resources.
+# Note that WingmanAI's support of whispercpp assumes you already know how to use the program.  It is just a connector.  If there are any issues with whispercpp you should direct them to the creator of whispercpp.
+# Only used if features > stt_provider is set to 'whispercpp' above.
+whispercpp:
+    base_url: http://127.0.0.1:8080 # This is the default for whispercpp, though you can change the host and port manually when launching your server with command line arguments.
+    autostart: false # Set this to true if you want to set paths to your whispercpp server.exe and model bin below and have wingman try to launch whispercpp server itself.
+    whispercpp_exe_path: C:\Whispercpp\server.exe # This is just an example, you will insert here the full path to your whispercpp server.exe file.  Only used if autostart is set to true.
+    whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin # This is just an example, you will insert here the full path to the whispercpp ggml model file you downloaded.  Only used if autostart is set to true.
+    temperature: 0.0 # Not typically changed, but you can review the whispercpp documentation to determine whether to experiment with this value.
+    language: en # Insert the whispercpp two letter code for your language if you intend to speak in another language.  Also make sure you do not use a english only whispercpp model if this is not set for en.
+
 # ────────────────────────────────── XVASYNTH ────────────────────────────────────
 # XVASynth is a free program on Steam that uses your local computer resources to generate text to speech using free voice models created by the community.
 # You can find the program here: https://store.steampowered.com/app/1765720/xVASynth/

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -1,25 +1,22 @@
 import os
-from os import path
 import subprocess
 import time
 import requests
-import json
 from api.enums import WingmanInitializationErrorType
-from api.interface import WhispercppSttConfig, WhispercppTranscript, WingmanInitializationError
+from api.interface import (
+    WhispercppSttConfig,
+    WhispercppTranscript,
+    WingmanInitializationError,
+)
 from services.printr import Printr
+
 
 class Whispercpp:
     def __init__(self, wingman_name: str):
         self.wingman_name = wingman_name
-        self.base_url: str = ""
-        self.autostart: bool = False
-        self.whispercpp_exe_path: str | None = None
-        self.whispercpp_model_path: str | None = None
-        self.temperature: float = 0.0
-        self.language: str = ""
         self.times_checked_whispercpp: int = 0
         self.printr = Printr()
-        
+
     def validate_config(
         self, config: WhispercppSttConfig, errors: list[WingmanInitializationError]
     ):
@@ -30,91 +27,112 @@ class Whispercpp:
             errors.append(
                 WingmanInitializationError(
                     wingman_name=self.wingman_name,
-                    message="Missing base url for whispercpp. Please provide a url where whispercpp can be reached.  By default this is http://127.0.0.1:8080.",
+                    message="Missing base_url for whispercpp.",
                     error_type=WingmanInitializationErrorType.INVALID_CONFIG,
                 )
             )
 
-        if config.autostart == True:
+        if config.autostart:
             if not config.autostart_settings:
                 errors.append(
                     WingmanInitializationError(
                         wingman_name=self.wingman_name,
-                        message="You chose to use whispercpp and autostart but did not include autostart_settings in your config, which is required for autostart to work.",
+                        message="Autostart for Whispercpp requires autostart_settings to be set.",
                         error_type=WingmanInitializationErrorType.INVALID_CONFIG,
                     )
                 )
-            if config.autostart_settings:
-                if not os.path.exists(config.autostart_settings.whispercpp_exe_path) or not os.path.exists(config.autostart_settings.whispercpp_model_path):
+            else:
+                if not os.path.exists(config.autostart_settings.whispercpp_exe_path):
                     errors.append(
                         WingmanInitializationError(
                             wingman_name=self.wingman_name,
-                            message="You chose to use whispercpp and chose autostart but did not provide proper paths to the whispercpp exe and model.  The path you set for whispercpp_exe_path or whispercpp_model_path could not be found on your system.",
+                            message=f"whispercpp_exe_path '{config.autostart_settings.whispercpp_exe_path}' could not be found on your system.",
+                            error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                        )
+                    )
+                if not os.path.exists(config.autostart_settings.whispercpp_model_path):
+                    errors.append(
+                        WingmanInitializationError(
+                            wingman_name=self.wingman_name,
+                            message=f"whispercpp_model_path '{config.autostart_settings.whispercpp_model_path}' could not be found on your system.",
                             error_type=WingmanInitializationErrorType.INVALID_CONFIG,
                         )
                     )
 
-        self.base_url = config.base_url
-        self.autostart = config.autostart
-        if self.autostart == True and config.autostart_settings:
-            self.whispercpp_exe_path = config.autostart_settings.whispercpp_exe_path
-            self.whispercpp_model_path = config.autostart_settings.whispercpp_model_path
-        self.temperature = config.temperature
-        self.language = config.language
         # check if whispercpp is running a few times, if cannot find it, send error
         while self.times_checked_whispercpp < 5:
-            is_running_error = self.__check_if_whispercpp_is_running()
+            is_running_error = self.__check_if_whispercpp_is_running(config=config)
             if is_running_error == "ok":
                 break
-            self.times_checked_whispercpp+=1
+            self.times_checked_whispercpp += 1
 
         if is_running_error != "ok":
-            errors.append(WingmanInitializationError(
+            errors.append(
+                WingmanInitializationError(
                     wingman_name=self.wingman_name,
                     message=is_running_error,
                     error_type=WingmanInitializationErrorType.INVALID_CONFIG,
-                ))
+                )
+            )
 
         return errors
 
-    def transcribe(self, filename: str, response_format: str = "json"):
-        url = self.base_url + '/inference'
+    def transcribe(
+        self, filename: str, config: WhispercppSttConfig, response_format: str = "json"
+    ):
+        url = config.base_url + "/inference"
         file_path = filename
-        files = {'file': open(file_path, 'rb')}
-        data = {'temperature': self.temperature, 'response_format': response_format,}
+        files = {"file": open(file_path, "rb")}
+        data = {
+            "temperature": config.temperature,
+            "response_format": response_format,
+        }
         try:
-            response = requests.post(url, files=files, data=data)
+            response = requests.post(url, files=files, data=data, timeout=10)
             response.raise_for_status()
             # Need to use a pydantic base model to enable openaiwingman to use same transcript.text call as it uses for openai which also uses a pydantic object, otherwise response.json would be fine here, which would return {"text":"transcription"}.
-            return WhispercppTranscript(text=response.json()["text"].strip(),language=self.language)
-        except:
+            return WhispercppTranscript(
+                text=response.json()["text"].strip(), language=config.language
+            )
+        except requests.HTTPError as e:
             self.printr.toast_error(
-                text="There was an error with the whispercpp transcription.  The request to the server failed."
+                text=f"Whispercpp transcription request failed: {e.strerror}"
             )
             return None
 
-    def __check_if_whispercpp_is_running(self):
+    def __check_if_whispercpp_is_running(self, config: WhispercppSttConfig):
         try:
-            response = requests.get(self.base_url)
+            response = requests.get(config.base_url, timeout=10)
             response.raise_for_status()
 
-        except requests.RequestException as e:
+        except requests.RequestException:
             time.sleep(1)
-            if self.times_checked_whispercpp == 1 and self.autostart == True:
-                #If not found, try to start whispercpp as a subprocess
-                subprocess.Popen([self.whispercpp_exe_path, "-m", self.whispercpp_model_path, "-l", self.language])
+            if self.times_checked_whispercpp == 1 and config.autostart:
+                # If not found, try to start whispercpp as a subprocess
+                subprocess.Popen(
+                    [
+                        config.autostart_settings.whispercpp_exe_path,
+                        "-m",
+                        config.autostart_settings.whispercpp_model_path,
+                        "-l",
+                        config.language,
+                    ]
+                )
                 time.sleep(5)
-            return "You chose Whispercpp for speech to text but the program does not appear to be running, and if you enabled autostart, autostart failed.  Please check your whispercpp install and your paths if you enabled autostart."
+            return "Whispercpp is not running and autostart failed."
 
         return "ok"
 
     # Currently unused but whispercpp supports loading models by functions so including for possible future dev use.
-    def load_whispercpp_model(self, whispercpp_model_path:str):
-        model_path = whispercpp_model_path
-        data = {'model': model_path,}
+    def load_whispercpp_model(
+        self, config: WhispercppSttConfig, whispercpp_model_path: str
+    ):
+        data = {
+            "model": whispercpp_model_path,
+        }
         try:
-            response = requests.post(self.base_url+"/load", data=data)
+            response = requests.post(config.base_url + "/load", data=data, timeout=10)
             response.raise_for_status()
             return "ok"
-        except:
+        except requests.HTTPError:
             return "There was an error with loading your whispercpp model. Double check your whispercpp install and model path."

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -1,0 +1,103 @@
+import requests
+import json
+import os
+import subprocess
+import time
+from api.enums import WingmanInitializationErrorType
+from api.interface import WhispercppSttConfig, WhispercppTranscript, WingmanInitializationError
+from os import path
+
+class Whispercpp:
+    def __init__(self, wingman_name: str, base_url: str, autostart: bool, whispercpp_exe_path: str, whispercpp_model_path: str, temperature: float, language: str, times_checked_whispercpp: int):
+        self.wingman_name = wingman_name if wingman_name else ""
+        self.base_url = base_url if base_url else "http://127.0.0.1:8080"
+        self.autostart = autostart if autostart else False
+        self.whispercpp_exe_path = whispercpp_exe_path if whispercpp_exe_path else None
+        self.whispercpp_model_path = whispercpp_model_path if whispercpp_model_path else None
+        self.temperature = temperature if temperature else 0.0
+        self.language = language if language else "en"
+        self.times_checked_whispercpp = 0
+        
+    def validate_config(self, config: WhispercppSttConfig, errors: list[WingmanInitializationError]):
+        if not errors:
+            errors = []
+
+        if not config.base_url:
+            errors.append(
+                WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message="Missing base url for whispercpp. Please provide a url where whispercpp can be reached.  By default this is http://127.0.0.1:8080.",
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                )
+            )
+
+        if config.autostart == True and (config.whispercpp_exe_path == None or config.whispercpp_model_path == None or not os.path.exists(config.whispercpp_exe_path) or not os.path.exists(config.whispercpp_model_path)):
+            errors.append(
+                WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message="You chose to use whispercpp and chose autostart but did not provide proper paths to the whispercpp exe and model.  Please turn autostart off or set / confirm the paths to the exe and model.",
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                )
+            )
+
+        self.base_url = config.base_url if config.base_url else "http://127.0.0.1:8080"
+        self.autostart = config.autostart if config.autostart else False
+        self.whispercpp_exe_path = config.whispercpp_exe_path if config.whispercpp_exe_path else None
+        self.whispercpp_model_path = config.whispercpp_model_path if config.whispercpp_model_path else None
+        self.temperature = config.temperature if config.temperature else 0.0
+        self.language = config.language if config.language else "en"
+        self.times_checked_whispercpp = 0
+        # check if whispercpp is running a few times, if cannot find it, send error
+        while self.times_checked_whispercpp < 5:
+            check = self.check_if_whispercpp_is_running()
+            if check == "ok":
+                break
+            self.times_checked_whispercpp+=1
+
+        if check != "ok":
+            errors.append(WingmanInitializationError(
+                    wingman_name=self.wingman_name,
+                    message=check,
+                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                ))
+
+        return errors
+
+    def transcribe(self, filename: str, response_format: str = "json"):
+        url = self.base_url + '/inference'
+        file_path = filename
+        files = {'file': open(file_path, 'rb')}
+        data = {'temperature': self.temperature, 'response_format': response_format,}
+        try:
+            response = requests.post(url, files=files, data=data)
+            response.raise_for_status()
+            # Need to use a pydantic base model to enable openaiwingman to use same transcript.text call as it uses for openai which also uses a pydantic object, otherwise response.json would be fine here, which would return {"text":"transcription"}.
+            return WhispercppTranscript(text=response.json()["text"].strip())
+        except:
+            return "There was an error with the whispercpp transcription.  The request to the server failed."
+
+    def check_if_whispercpp_is_running(self):
+        try:
+            response = requests.get(self.base_url)
+            response.raise_for_status()
+
+        except requests.RequestException as e:
+            time.sleep(1)
+            if self.times_checked_whispercpp == 1 and self.autostart == True:
+                #If not found, try to start whispercpp as a subprocess
+                subprocess.Popen([self.whispercpp_exe_path, "-m", self.whispercpp_model_path, "-l", self.language])
+                time.sleep(5)
+            return "ERROR: You chose Whispercpp for speech to text but the program does not appear to be running, and if you enabled autostart, autostart failed.  Please check your whispercpp install and your paths if you enabled autostart."
+
+        return "ok"
+
+    # Currently unused but whispercpp supports loading models by functions so including for possible future dev use.
+    def load_whispercpp_model(self, whispercpp_model_path:str):
+        model_path = whispercpp_model_path
+        data = {'model': model_path,}
+        try:
+            response = requests.post(self.base_url+"/load", data=data)
+            response.raise_for_status()
+            return "ok"
+        except:
+            return "There was an error with loading your whispercpp model. Double check your whispercpp install and model path."

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -30,7 +30,7 @@ class Whispercpp:
                 )
             )
 
-        if config.autostart == True and (config.whispercpp_exe_path == None or config.whispercpp_model_path == None or not os.path.exists(config.whispercpp_exe_path) or not os.path.exists(config.whispercpp_model_path)):
+        if config.autostart == True and (config.autostart_settings.whispercpp_exe_path == None or config.autostart_settings.whispercpp_model_path == None or not os.path.exists(config.autostart_settings.whispercpp_exe_path) or not os.path.exists(config.autostart_settings.whispercpp_model_path)):
             errors.append(
                 WingmanInitializationError(
                     wingman_name=self.wingman_name,
@@ -41,10 +41,10 @@ class Whispercpp:
 
         self.base_url = config.base_url
         self.autostart = config.autostart
-        if config.whispercpp_exe_path:
-            self.whispercpp_exe_path = config.whispercpp_exe_path
-        if config.whispercpp_model_path:
-            self.whispercpp_model_path = config.whispercpp_model_path
+        if config.autostart_settings.whispercpp_exe_path:
+            self.whispercpp_exe_path = config.autostart_settings.whispercpp_exe_path
+        if config.autostart_settings.whispercpp_model_path:
+            self.whispercpp_model_path = config.autostart_settings.whispercpp_model_path
         self.temperature = config.temperature
         self.language = config.language
         # check if whispercpp is running a few times, if cannot find it, send error

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -1,14 +1,16 @@
-import requests
-import json
 import os
+from os import path
 import subprocess
 import time
+import requests
+import json
 from api.enums import WingmanInitializationErrorType
 from api.interface import WhispercppSttConfig, WhispercppTranscript, WingmanInitializationError
-from os import path
+from services.printr import Printr
 
 class Whispercpp:
-    def __init__(self):
+    def __init__(self, wingman_name: str):
+        self.wingman_name = wingman_name
         self.base_url: str = ""
         self.autostart: bool = False
         self.whispercpp_exe_path: str | None = None
@@ -16,8 +18,11 @@ class Whispercpp:
         self.temperature: float = 0.0
         self.language: str = ""
         self.times_checked_whispercpp: int = 0
+        self.printr = Printr()
         
-    def validate_config(self, config: WhispercppSttConfig, errors: list[WingmanInitializationError]):
+    def validate_config(
+        self, config: WhispercppSttConfig, errors: list[WingmanInitializationError]
+    ):
         if not errors:
             errors = []
 
@@ -30,34 +35,43 @@ class Whispercpp:
                 )
             )
 
-        if config.autostart == True and (config.autostart_settings.whispercpp_exe_path == None or config.autostart_settings.whispercpp_model_path == None or not os.path.exists(config.autostart_settings.whispercpp_exe_path) or not os.path.exists(config.autostart_settings.whispercpp_model_path)):
-            errors.append(
-                WingmanInitializationError(
-                    wingman_name=self.wingman_name,
-                    message="You chose to use whispercpp and chose autostart but did not provide proper paths to the whispercpp exe and model.  Please turn autostart off or set / confirm the paths to the exe and model.",
-                    error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+        if config.autostart == True:
+            if not config.autostart_settings:
+                errors.append(
+                    WingmanInitializationError(
+                        wingman_name=self.wingman_name,
+                        message="You chose to use whispercpp and autostart but did not include autostart_settings in your config, which is required for autostart to work.",
+                        error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                    )
                 )
-            )
+            if config.autostart_settings:
+                if not os.path.exists(config.autostart_settings.whispercpp_exe_path) or not os.path.exists(config.autostart_settings.whispercpp_model_path):
+                    errors.append(
+                        WingmanInitializationError(
+                            wingman_name=self.wingman_name,
+                            message="You chose to use whispercpp and chose autostart but did not provide proper paths to the whispercpp exe and model.  The path you set for whispercpp_exe_path or whispercpp_model_path could not be found on your system.",
+                            error_type=WingmanInitializationErrorType.INVALID_CONFIG,
+                        )
+                    )
 
         self.base_url = config.base_url
         self.autostart = config.autostart
-        if config.autostart_settings.whispercpp_exe_path:
+        if self.autostart == True and config.autostart_settings:
             self.whispercpp_exe_path = config.autostart_settings.whispercpp_exe_path
-        if config.autostart_settings.whispercpp_model_path:
             self.whispercpp_model_path = config.autostart_settings.whispercpp_model_path
         self.temperature = config.temperature
         self.language = config.language
         # check if whispercpp is running a few times, if cannot find it, send error
         while self.times_checked_whispercpp < 5:
-            check = self.check_if_whispercpp_is_running()
-            if check == "ok":
+            is_running_error = self.__check_if_whispercpp_is_running()
+            if is_running_error == "ok":
                 break
             self.times_checked_whispercpp+=1
 
-        if check != "ok":
+        if is_running_error != "ok":
             errors.append(WingmanInitializationError(
                     wingman_name=self.wingman_name,
-                    message=check,
+                    message=is_running_error,
                     error_type=WingmanInitializationErrorType.INVALID_CONFIG,
                 ))
 
@@ -74,9 +88,12 @@ class Whispercpp:
             # Need to use a pydantic base model to enable openaiwingman to use same transcript.text call as it uses for openai which also uses a pydantic object, otherwise response.json would be fine here, which would return {"text":"transcription"}.
             return WhispercppTranscript(text=response.json()["text"].strip(),language=self.language)
         except:
-            return "There was an error with the whispercpp transcription.  The request to the server failed."
+            self.printr.toast_error(
+                text="There was an error with the whispercpp transcription.  The request to the server failed."
+            )
+            return None
 
-    def check_if_whispercpp_is_running(self):
+    def __check_if_whispercpp_is_running(self):
         try:
             response = requests.get(self.base_url)
             response.raise_for_status()
@@ -87,7 +104,7 @@ class Whispercpp:
                 #If not found, try to start whispercpp as a subprocess
                 subprocess.Popen([self.whispercpp_exe_path, "-m", self.whispercpp_model_path, "-l", self.language])
                 time.sleep(5)
-            return "ERROR: You chose Whispercpp for speech to text but the program does not appear to be running, and if you enabled autostart, autostart failed.  Please check your whispercpp install and your paths if you enabled autostart."
+            return "You chose Whispercpp for speech to text but the program does not appear to be running, and if you enabled autostart, autostart failed.  Please check your whispercpp install and your paths if you enabled autostart."
 
         return "ok"
 

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -72,7 +72,7 @@ class Whispercpp:
             response = requests.post(url, files=files, data=data)
             response.raise_for_status()
             # Need to use a pydantic base model to enable openaiwingman to use same transcript.text call as it uses for openai which also uses a pydantic object, otherwise response.json would be fine here, which would return {"text":"transcription"}.
-            return WhispercppTranscript(text=response.json()["text"].strip())
+            return WhispercppTranscript(text=response.json()["text"].strip(),language=self.language)
         except:
             return "There was an error with the whispercpp transcription.  The request to the server failed."
 

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -8,15 +8,14 @@ from api.interface import WhispercppSttConfig, WhispercppTranscript, WingmanInit
 from os import path
 
 class Whispercpp:
-    def __init__(self, wingman_name: str, base_url: str, autostart: bool, whispercpp_exe_path: str, whispercpp_model_path: str, temperature: float, language: str, times_checked_whispercpp: int):
-        self.wingman_name = wingman_name if wingman_name else ""
-        self.base_url = base_url if base_url else "http://127.0.0.1:8080"
-        self.autostart = autostart if autostart else False
-        self.whispercpp_exe_path = whispercpp_exe_path if whispercpp_exe_path else None
-        self.whispercpp_model_path = whispercpp_model_path if whispercpp_model_path else None
-        self.temperature = temperature if temperature else 0.0
-        self.language = language if language else "en"
-        self.times_checked_whispercpp = 0
+    def __init__(self):
+        self.base_url: str = ""
+        self.autostart: bool = False
+        self.whispercpp_exe_path: str | None = None
+        self.whispercpp_model_path: str | None = None
+        self.temperature: float = 0.0
+        self.language: str = ""
+        self.times_checked_whispercpp: int = 0
         
     def validate_config(self, config: WhispercppSttConfig, errors: list[WingmanInitializationError]):
         if not errors:
@@ -40,13 +39,14 @@ class Whispercpp:
                 )
             )
 
-        self.base_url = config.base_url if config.base_url else "http://127.0.0.1:8080"
-        self.autostart = config.autostart if config.autostart else False
-        self.whispercpp_exe_path = config.whispercpp_exe_path if config.whispercpp_exe_path else None
-        self.whispercpp_model_path = config.whispercpp_model_path if config.whispercpp_model_path else None
-        self.temperature = config.temperature if config.temperature else 0.0
-        self.language = config.language if config.language else "en"
-        self.times_checked_whispercpp = 0
+        self.base_url = config.base_url
+        self.autostart = config.autostart
+        if config.whispercpp_exe_path:
+            self.whispercpp_exe_path = config.whispercpp_exe_path
+        if config.whispercpp_model_path:
+            self.whispercpp_model_path = config.whispercpp_model_path
+        self.temperature = config.temperature
+        self.language = config.language
         # check if whispercpp is running a few times, if cannot find it, send error
         while self.times_checked_whispercpp < 5:
             check = self.check_if_whispercpp_is_running()

--- a/services/config_manager.py
+++ b/services/config_manager.py
@@ -725,6 +725,7 @@ class ConfigManager:
             "elevenlabs",
             "azure",
             "xvasynth",
+            "whispercpp",
         ]:
             if key in general:
                 # Use copy.deepcopy to ensure a full deep copy is made and original is untouched.

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -151,8 +151,10 @@ class OpenAiWingman(Wingman):
             wingman_name=self.name,
         )
         self.xvasynth.validate_config(config=self.config.xvasynth, errors=errors)
-        
-    async def validate_and_set_whispercpp(self, errors: list[WingmanInitializationError]):
+
+    async def validate_and_set_whispercpp(
+        self, errors: list[WingmanInitializationError]
+    ):
         self.whispercpp = Whispercpp(
             wingman_name=self.name,
         )
@@ -182,7 +184,7 @@ class OpenAiWingman(Wingman):
             )
         elif self.stt_provider == SttProvider.WHISPERCPP:
             transcript = self.whispercpp.transcribe(
-                filename=audio_input_wav,
+                filename=audio_input_wav, config=self.config.whispercpp
             )
         else:
             transcript = self.openai.transcribe(filename=audio_input_wav)

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -149,14 +149,13 @@ class OpenAiWingman(Wingman):
     async def validate_and_set_xvasynth(self, errors: list[WingmanInitializationError]):
         self.xvasynth = XVASynth(
             wingman_name=self.name,
-            xvasynth_path=self.config.xvasynth.xvasynth_path,
-            process_device=self.config.xvasynth.process_device,
-            times_checked_xvasynth=0,
         )
         self.xvasynth.validate_config(config=self.config.xvasynth, errors=errors)
         
     async def validate_and_set_whispercpp(self, errors: list[WingmanInitializationError]):
-        self.whispercpp = Whispercpp()
+        self.whispercpp = Whispercpp(
+            wingman_name=self.name,
+        )
         self.whispercpp.validate_config(config=self.config.whispercpp, errors=errors)
 
     async def _transcribe(self, audio_input_wav: str) -> str | None:

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -193,7 +193,6 @@ class OpenAiWingman(Wingman):
         elif self.stt_provider == SttProvider.WHISPERCPP:
             transcript = self.whispercpp.transcribe(
                 filename=audio_input_wav,
-                response_format=response_format,
             )
         else:
             transcript = self.openai.transcribe(filename=audio_input_wav)

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -14,6 +14,7 @@ from providers.edge import Edge
 from providers.elevenlabs import ElevenLabs
 from providers.open_ai import OpenAi, OpenAiAzure
 from providers.xvasynth import XVASynth
+from providers.whispercpp import Whispercpp
 from services.printr import Printr
 from wingmen.wingman import Wingman
 
@@ -50,6 +51,7 @@ class OpenAiWingman(Wingman):
         self.openai_azure: OpenAiAzure = None
         self.elevenlabs: ElevenLabs = None
         self.xvasynth: XVASynth = None
+        self.whispercpp: Whispercpp = None
 
         self.pending_tool_calls = []
         self.last_gpt_call = None
@@ -72,8 +74,12 @@ class OpenAiWingman(Wingman):
 
         if self.uses_provider("elevenlabs"):
             await self.validate_and_set_elevenlabs(errors)
+
         if self.uses_provider("xvasynth"):
             await self.validate_and_set_xvasynth(errors)
+
+        if self.uses_provider("whispercpp"):
+            await self.validate_and_set_whispercpp(errors)
 
         await self.validate_and_set_azure(errors)
 
@@ -105,6 +111,8 @@ class OpenAiWingman(Wingman):
             return self.tts_provider == TtsProvider.ELEVENLABS
         elif provider_type == "xvasynth":
             return self.tts_provider == TtsProvider.XVASYNTH
+        elif provider_type == "whispercpp":
+            return self.stt_provider == SttProvider.WHISPERCPP
         return False
 
     async def validate_and_set_openai(self, errors: list[WingmanInitializationError]):
@@ -146,6 +154,19 @@ class OpenAiWingman(Wingman):
             times_checked_xvasynth=0,
         )
         self.xvasynth.validate_config(config=self.config.xvasynth, errors=errors)
+        
+    async def validate_and_set_whispercpp(self, errors: list[WingmanInitializationError]):
+        self.whispercpp = Whispercpp(
+            wingman_name=self.name,
+            base_url = self.config.whispercpp.base_url,
+            autostart = self.config.whispercpp.autostart,
+            whispercpp_exe_path = self.config.whispercpp.whispercpp_exe_path,
+            whispercpp_model_path = self.config.whispercpp.whispercpp_model_path,
+            temperature = self.config.whispercpp.temperature,
+            language = self.config.whispercpp.language,
+            times_checked_whispercpp=0,
+        )
+        self.whispercpp.validate_config(config=self.config.whispercpp, errors=errors)
 
     async def _transcribe(self, audio_input_wav: str) -> str | None:
         """Transcribes the recorded audio to text using the OpenAI Whisper API.
@@ -168,6 +189,11 @@ class OpenAiWingman(Wingman):
                 filename=audio_input_wav,
                 api_key=self.azure_api_keys["tts"],
                 config=self.config.azure.stt,
+            )
+        elif self.stt_provider == SttProvider.WHISPERCPP:
+            transcript = self.whispercpp.transcribe(
+                filename=audio_input_wav,
+                response_format=response_format,
             )
         else:
             transcript = self.openai.transcribe(filename=audio_input_wav)

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -156,16 +156,7 @@ class OpenAiWingman(Wingman):
         self.xvasynth.validate_config(config=self.config.xvasynth, errors=errors)
         
     async def validate_and_set_whispercpp(self, errors: list[WingmanInitializationError]):
-        self.whispercpp = Whispercpp(
-            wingman_name=self.name,
-            base_url = self.config.whispercpp.base_url,
-            autostart = self.config.whispercpp.autostart,
-            whispercpp_exe_path = self.config.whispercpp.whispercpp_exe_path,
-            whispercpp_model_path = self.config.whispercpp.whispercpp_model_path,
-            temperature = self.config.whispercpp.temperature,
-            language = self.config.whispercpp.language,
-            times_checked_whispercpp=0,
-        )
+        self.whispercpp = Whispercpp()
         self.whispercpp.validate_config(config=self.config.whispercpp, errors=errors)
 
     async def _transcribe(self, audio_input_wav: str) -> str | None:


### PR DESCRIPTION
-Add support for whispercpp server as a free local stt provider (https://github.com/ggerganov/whisper.cpp/releases)

-Allow user to configure variables to path to their whispercpp server.exe and chosen model and allow wingman ai to attempt to autostart the program to reduce friction, otherwise expect user to start server on their own

-Tested with Windows 11, not tested on MacOS