### PR TITLE
fix audio input configuration not working

### DIFF
--- a/services/audio_recorder.py
+++ b/services/audio_recorder.py
@@ -21,13 +21,23 @@ class AudioRecorder:
     ):
         self.file_path = path.join(get_writable_dir(RECORDING_PATH), RECORDING_FILE)
         self.samplerate = samplerate
+        self.channels = channels
         self.is_recording = False
         self.recording = None
+        self.recstream = None
+
+        # default devices are fixed once this is called
+        # so this methods needs to be called every time a new device is configured
+        self.update_input_stream() 
+
+    def update_input_stream(self):
+        if self.recstream is not None:
+            self.recstream.close()
 
         self.recstream = sounddevice.InputStream(
             callback=self.__handle_input_stream,
-            channels=channels,
-            samplerate=samplerate,
+            channels=self.channels,
+            samplerate=self.samplerate,
         )
 
     def __handle_input_stream(self, indata, _frames, _time, _status):

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -219,6 +219,7 @@ class WingmanCore:
         # restore settings
         configured_devices = self.get_configured_audio_devices()
         sd.default.device = (configured_devices.input, configured_devices.output)
+        self.audio_recorder.update_input_stream()
 
     def on_press(self, key=None, button=None):
         if self.tower and self.active_recording["key"] == "":
@@ -433,6 +434,7 @@ class WingmanCore:
     ):
         # set the devices
         sd.default.device = input_device, output_device
+        self.audio_recorder.update_input_stream()
 
         # save settings
         self.config_manager.settings_config.audio = AudioSettings(


### PR DESCRIPTION
New method `update_input_stream` in AudioRecorder, that needs to be called everytime the input device is changed.