### PR TITLE
Allow hotkeys to trigger if pressed together with other keys

### DIFF
--- a/wingman_core.py
+++ b/wingman_core.py
@@ -290,7 +290,8 @@ class WingmanCore(WebSocketUser):
         if isinstance(hotkey, list):
             codes = hotkey
 
-        is_pressed = set(codes) == set(self.key_events.keys())
+        # check if all hotkey codes are in the key events code list
+        is_pressed = all(code in self.key_events for code in codes)
 
         return is_pressed
 


### PR DESCRIPTION
Simple change to allow hotkeys to trigger, if the required key list is fully contained withing the list of currently pressed keys.