### PR TITLE
Add keyboard release and press options

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -130,6 +130,7 @@ class SummarizeProvider(Enum):
 class KeyboardRecordingType(Enum):
     SINGLE = "single"
     MACRO = "macro"
+    MACRO_ADVANCED = "macro_advanced"
 
 
 class WingmanProRegion(Enum):

--- a/api/interface.py
+++ b/api/interface.py
@@ -336,6 +336,11 @@ class CommandKeyboardConfig(BaseModel):
     hold: Optional[float] = None
     """The duration the key will be pressed in seconds. Optional."""
 
+    press: Optional[bool] = None
+    """Whether to press the key. Optional."""
+
+    release: Optional[bool] = None
+    """Whether to release the key. Optional."""
 
 class CommandMouseConfig(BaseModel):
     button: Optional[str] = None

--- a/api/interface.py
+++ b/api/interface.py
@@ -333,6 +333,9 @@ class CommandKeyboardConfig(BaseModel):
     hotkey_codes: Optional[list[int]] = None
     """The hotkey codes. Can be a single key like 65 or a combination like 162+160+65. Optional."""
 
+    hotkey_extended: Optional[bool] = None
+    """Whether the hotkey is an extended key. Optional."""
+
     hold: Optional[float] = None
     """The duration the key will be pressed in seconds. Optional."""
 

--- a/keyboard/keyboard/__init__.py
+++ b/keyboard/keyboard/__init__.py
@@ -510,7 +510,6 @@ def direct_event(scancode, event_type):
     """
     Sends a key event directly to the OS, without any processing.
     """
-    print(f"direct_event({scancode}, {event_type})")
     _os_keyboard.direct_event(scancode, event_type)
 
 # Alias.

--- a/keyboard/keyboard/__init__.py
+++ b/keyboard/keyboard/__init__.py
@@ -506,6 +506,13 @@ def send(hotkey, do_press=True, do_release=True):
 
     _listener.is_replaying = False
 
+def direct_event(scancode, event_type):
+    """
+    Sends a key event directly to the OS, without any processing.
+    """
+    print(f"direct_event({scancode}, {event_type})")
+    _os_keyboard.direct_event(scancode, event_type)
+
 # Alias.
 press_and_release = send
 

--- a/keyboard/keyboard/_darwinkeyboard.py
+++ b/keyboard/keyboard/_darwinkeyboard.py
@@ -472,6 +472,13 @@ key_controller = KeyController()
 def init():
     key_controller = KeyController()
 
+def direct_event(scan_code, event_type):
+    """ Sends a key event directly, without any processing """
+    if event_type == 0 or event_type == 1:
+        key_controller.press(scan_code)
+    elif event_type == 2 or event_type == 3:
+        key_controller.release(scan_code)
+
 def press(scan_code):
     """ Sends a 'down' event for the specified scan code """
     key_controller.press(scan_code)

--- a/keyboard/keyboard/_keyboard_event.py
+++ b/keyboard/keyboard/_keyboard_event.py
@@ -20,20 +20,22 @@ class KeyboardEvent(object):
     device = None
     modifiers = None
     is_keypad = None
+    is_extended = None
 
-    def __init__(self, event_type, scan_code, name=None, time=None, device=None, modifiers=None, is_keypad=None):
+    def __init__(self, event_type, scan_code, name=None, time=None, device=None, modifiers=None, is_keypad=None, is_extended=None):
         self.event_type = event_type
         self.scan_code = scan_code
         self.time = now() if time is None else time
         self.device = device
         self.is_keypad = is_keypad
         self.modifiers = modifiers
+        self.is_extended = is_extended
         if name:
             self.name = normalize_name(name)
 
     def to_json(self, ensure_ascii=False):
         attrs = dict(
-            (attr, getattr(self, attr)) for attr in ['event_type', 'scan_code', 'name', 'time', 'device', 'is_keypad', 'modifiers']
+            (attr, getattr(self, attr)) for attr in ['event_type', 'scan_code', 'name', 'time', 'device', 'is_keypad', 'modifiers', 'is_extended']
             if not attr.startswith('_')
         )
         return json.dumps(attrs, ensure_ascii=ensure_ascii)

--- a/keyboard/keyboard/_nixkeyboard.py
+++ b/keyboard/keyboard/_nixkeyboard.py
@@ -152,6 +152,9 @@ def listen(callback):
         is_keypad = scan_code in keypad_scan_codes
         callback(KeyboardEvent(event_type=event_type, scan_code=scan_code, name=name, time=time, device=device_id, is_keypad=is_keypad, modifiers=pressed_modifiers_tuple))
 
+def direct_event(scan_code, event_type):
+    write_event(scan_code, event_type == 0 or event_type == 1)
+
 def write_event(scan_code, is_down):
     build_device()
     device.write_event(EV_KEY, scan_code, int(is_down))

--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -111,8 +111,6 @@ class CommandHandler:
         # self.timeout_task = WebSocketUser.ensure_async(self._start_timeout(10))
 
         def _on_key_event(event):
-            print(event.name, event.event_type, event.scan_code, event.time)
-
             self.recorded_keys.append(event)
             if command.recording_type == KeyboardRecordingType.SINGLE and self._is_hotkey_recording_finished(self.recorded_keys):
                 WebSocketUser.ensure_async(self.handle_stop_recording(None, None))

--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -119,7 +119,7 @@ class CommandHandler:
                 WebSocketUser.ensure_async(self.handle_stop_recording(None, None, command.recording_type))
             if event.scan_code == 58 or event.scan_code == 70 or (event.scan_code == 69 and event.is_extended):
                 # let capslock, numlock or scrolllock through, as it changes following keypresses
-                keyboard.direct_event(event.scan_code, (0 if event.event_type == "down" else 2)+event.is_extended)
+                keyboard.direct_event(event.scan_code, (0 if event.event_type == "down" else 2)+int(event.is_extended))
 
             self.recorded_keys.append(event)
             if command.recording_type == KeyboardRecordingType.SINGLE and self._is_hotkey_recording_finished(self.recorded_keys):

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -404,8 +404,8 @@ class Wingman:
 
         for action in command.actions:
             if action.keyboard:
-                # legacy key presses
-                if ( not action.keyboard.press and not action.keyboard.release) or ( action.keyboard.press is True and action.keyboard.release is True ):
+                # grouped key presses
+                if action.keyboard.press == action.keyboard.release:
                     if action.keyboard.hold:
                         keyboard.press(
                             action.keyboard.hotkey_codes or action.keyboard.hotkey
@@ -418,7 +418,7 @@ class Wingman:
                         keyboard.send(
                             action.keyboard.hotkey_codes or action.keyboard.hotkey
                         )
-                # accurate key presses
+                # timelined key presses
                 else:
                     if action.keyboard.press:
                         keyboard.press(

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -404,18 +404,30 @@ class Wingman:
 
         for action in command.actions:
             if action.keyboard:
-                if action.keyboard.hold:
-                    keyboard.press(
-                        action.keyboard.hotkey_codes or action.keyboard.hotkey
-                    )
-                    time.sleep(action.keyboard.hold)
-                    keyboard.release(
-                        action.keyboard.hotkey_codes or action.keyboard.hotkey
-                    )
+                # legacy key presses
+                if ( not action.keyboard.press and not action.keyboard.release) or ( action.keyboard.press is True and action.keyboard.release is True ):
+                    if action.keyboard.hold:
+                        keyboard.press(
+                            action.keyboard.hotkey_codes or action.keyboard.hotkey
+                        )
+                        time.sleep(action.keyboard.hold)
+                        keyboard.release(
+                            action.keyboard.hotkey_codes or action.keyboard.hotkey
+                        )
+                    else:
+                        keyboard.send(
+                            action.keyboard.hotkey_codes or action.keyboard.hotkey
+                        )
+                # accurate key presses
                 else:
-                    keyboard.send(
-                        action.keyboard.hotkey_codes or action.keyboard.hotkey
-                    )
+                    if action.keyboard.press:
+                        keyboard.press(
+                            action.keyboard.hotkey_codes or action.keyboard.hotkey
+                        )
+                    if action.keyboard.release:
+                        keyboard.release(
+                            action.keyboard.hotkey_codes or action.keyboard.hotkey
+                        )
 
             if action.mouse:
                 if action.mouse.move_to:

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -365,7 +365,7 @@ class Wingman:
 
         if len(command.actions or []) > 0 and not self.debug:
             await printr.print_async(
-                f"❖ Executing command: {command.name}", color=LogType.INFO
+                f"Executing command: {command.name}", color=LogType.INFO
             )
             if not self.debug:
                 # in debug mode we already printed the separate execution times
@@ -374,7 +374,7 @@ class Wingman:
 
         if len(command.actions or []) == 0:
             await printr.print_async(
-                f"❖ No actions found for command: {command.name}", color=LogType.WARNING
+                f"No actions found for command: {command.name}", color=LogType.WARNING
             )
 
         if self.debug:
@@ -404,30 +404,23 @@ class Wingman:
 
         for action in command.actions:
             if action.keyboard:
-                # grouped key presses
                 if action.keyboard.press == action.keyboard.release:
-                    if action.keyboard.hold:
-                        keyboard.press(
-                            action.keyboard.hotkey_codes or action.keyboard.hotkey
-                        )
-                        time.sleep(action.keyboard.hold)
-                        keyboard.release(
-                            action.keyboard.hotkey_codes or action.keyboard.hotkey
-                        )
+                    # compressed key events
+                    hold = action.keyboard.hold or 0.1
+                    if(action.keyboard.hotkey_codes and len(action.keyboard.hotkey_codes) == 1):
+                        keyboard.direct_event(action.keyboard.hotkey_codes[0], 0+(1 if action.keyboard.hotkey_extended else 0))
+                        time.sleep(hold)
+                        keyboard.direct_event(action.keyboard.hotkey_codes[0], 2+(1 if action.keyboard.hotkey_extended else 0))
                     else:
-                        keyboard.send(
-                            action.keyboard.hotkey_codes or action.keyboard.hotkey
-                        )
-                # timelined key presses
+                        keyboard.press(action.keyboard.hotkey_codes or action.keyboard.hotkey)
+                        time.sleep(hold)
+                        keyboard.release(action.keyboard.hotkey_codes or action.keyboard.hotkey)
                 else:
-                    if action.keyboard.press:
-                        keyboard.press(
-                            action.keyboard.hotkey_codes or action.keyboard.hotkey
-                        )
-                    if action.keyboard.release:
-                        keyboard.release(
-                            action.keyboard.hotkey_codes or action.keyboard.hotkey
-                        )
+                    # single key events
+                    if(action.keyboard.hotkey_codes and len(action.keyboard.hotkey_codes) == 1):
+                        keyboard.direct_event(action.keyboard.hotkey_codes[0], (0 if action.keyboard.press else 2)+(1 if action.keyboard.hotkey_extended else 0))
+                    else:
+                        keyboard.send(action.keyboard.hotkey_codes or action.keyboard.hotkey, action.keyboard.press, action.keyboard.release)
 
             if action.mouse:
                 if action.mouse.move_to:


### PR DESCRIPTION
Keyboard actions in the config have optional `release` and `press` flags added to them.

If none or both are set, they are executed as already known and hold time is taken into account.
If only `press` or `release` is set, only the specific action is triggered and the wait time in between keyboard actions basically becomes the hold time.

This allows key presses to sustain several different key presses in between.

But it will need some GUI implementation, as these recordings are currently not shown well.
Also it currently only triggers, when a macro recording is stopped with the `esc`-key.
If stopped with the "Stop recording"-button, it is recorded as currently known in the system.

Apart from that, I also enabled keyboard suppression on command recording. This allows all keys, including `F5`, `Ctrl+r` and more to be recorded, that previously could cause issues. But this comes with the cost of `esc`-key no longer being recordable.

A config sample with ctrl hold down from beginning to end: (Meant for Helldivers 2, but macros don't work there :( )
```
- actions:
  - keyboard:
      hotkey: strg
      hotkey_codes:
      - 29
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: s
      hotkey_codes:
      - 31
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: s
      hotkey_codes:
      - 31
      release: true
  - wait: 0.01
  - keyboard:
      hotkey: a
      hotkey_codes:
      - 30
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: a
      hotkey_codes:
      - 30
      release: true
  - wait: 0.01
  - keyboard:
      hotkey: s
      hotkey_codes:
      - 31
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: s
      hotkey_codes:
      - 31
      release: true
  - wait: 0.01
  - keyboard:
      hotkey: w
      hotkey_codes:
      - 17
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: w
      hotkey_codes:
      - 17
      release: true
  - wait: 0.01
  - keyboard:
      hotkey: d
      hotkey_codes:
      - 32
      press: true
  - wait: 0.01
  - keyboard:
      hotkey: d
      hotkey_codes:
      - 32
      release: true
  - wait: 0.01
  - keyboard:
      hotkey: strg
      hotkey_codes:
      - 29
      release: true
  force_instant_activation: false
  instant_activation: []
  is_system_command: false
  name: RequestMachineGun
  responses: []
  ```
  
  PS: This also includes #131 , sorry.