### PR TITLE
Add force instant activation to star citizen self destruct

### DIFF
--- a/configs/templates/_Star Citizen/Computer.template.yaml
+++ b/configs/templates/_Star Citizen/Computer.template.yaml
@@ -313,7 +313,13 @@ commands:
           hotkey: right alt+y
   # ───────────────────────────────────────────
   - name: SelfDestruct
-    keys:
+    force_instant_activation: true
+    instant_activation:
+      - initiate self destruct
+      - activate self destruct
+    responses:
+      - Self-destruct engaged. Evacuation procedures recommended.
+      - Confirmed. Self-destruct in progress.
     actions:
       - keyboard:
           hotkey: backspace

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -290,7 +290,8 @@ class WingmanCore(WebSocketUser):
         if isinstance(hotkey, list):
             codes = hotkey
 
-        is_pressed = set(codes) == set(self.key_events.keys())
+        # check if all hotkey codes are in the key events code list
+        is_pressed = all(code in self.key_events for code in codes)
 
         return is_pressed
 


### PR DESCRIPTION
Added a force instant activation to star citizen template's self destruct command.
This does make sense, as it can be a critical error, if activated by AI on accident.

Attention: This also includes #131 as this is based on my develop branch and I didn't move that old one into its own branch back when I created that PR. Sorry.