### PR TITLE
Audio settings based on name instead of index

### DIFF
--- a/api/interface.py
+++ b/api/interface.py
@@ -100,11 +100,13 @@ class AudioDevice(BaseModel):
 
 # CONFIG MODELS
 
+class AudioDeviceSettings(BaseModel):
+    hostapi: Optional[int] = 0
+    name: str
 
 class AudioSettings(BaseModel):
-    input: Optional[int] = None
-    output: Optional[int] = None
-
+    input: Optional[int|AudioDeviceSettings] = None
+    output: Optional[int|AudioDeviceSettings] = None
 
 class WhispercppAutostartSettingsConfig(BaseModel):
     whispercpp_exe_path: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyaudio~=0.2.14
 pydantic~=2.6.4
 pydirectinput-rgx==2.1.1
 pyinstaller==6.5.0
+python-multipart==0.0.9
 PyYAML~=6.0.1
 requests~=2.31.0
 scipy~=1.13.0

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -20,6 +20,7 @@ class SettingsService:
         self.printr = Printr()
         self.config_manager = config_manager
         self.config_service = config_service
+        self.converted_audio_settings = False
         self.settings = self.get_settings()
         self.settings_events = PubSub()
 
@@ -67,9 +68,10 @@ class SettingsService:
     # GET /settings
     def get_settings(self):
         config = self.config_manager.settings_config
-        config.audio = self.get_audio_settings_indexed()
+        config.audio = self.get_audio_settings_indexed(not self.converted_audio_settings)
+        self.converted_audio_settings = True
         return config
-    
+
     def get_audio_settings_indexed(self, write: bool = True) -> AudioSettings:
         input_device = None
         output_device = None
@@ -88,9 +90,10 @@ class SettingsService:
                         input_device = input_settings
                         device = sd.query_devices(input_settings)
                         if not device["max_input_channels"]:
-                            self.printr.print(
-                                "Configured input device is not an input device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                            )
+                            if write:
+                                self.printr.print(
+                                    "Configured input device is not an input device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                )
                             input_device = None
                         else:
                             input_name = sd.query_devices()[input_settings]["name"]
@@ -98,28 +101,32 @@ class SettingsService:
                             input_settings = AudioDeviceSettings(
                                 name=input_name, hostapi=input_hostapi
                             )
-                            self.printr.print(
-                                f"Using input device '{input_name}'.", color=LogType.INFO, server_only=True
-                            )
+                            if write:
+                                self.printr.print(
+                                    f"Using input device '{input_name}'.", color=LogType.INFO, server_only=True
+                                )
                     else:
-                        self.printr.print(
-                            "Configured input device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                        )
+                        if write:
+                            self.printr.print(
+                                "Configured input device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                            )
                         input_device = None
                 elif isinstance(input_settings, AudioDeviceSettings):
                     # get id with name and hostapi
                     for device in sd.query_devices():
                         if device["max_input_channels"] > 0 and device["name"] == input_settings.name and device["hostapi"] == input_settings.hostapi:
-                            self.printr.print(
-                                f"Using input device '{device["name"]}'.", color=LogType.INFO, server_only=True
-                            )
+                            if write:
+                                self.printr.print(
+                                    f"Using input device '{device["name"]}'.", color=LogType.INFO, server_only=True
+                                )
                             input_device = device["index"]
                             break
                     if input_device is None:
-                        self.printr.print(
-                            f"Configured input device '{input_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                        )
-            else:
+                        if write:
+                            self.printr.print(
+                                f"Configured input device '{input_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                            )
+            elif write:
                 self.printr.print(
                     "No input device set. Using default.", color=LogType.INFO, server_only=True
                 )
@@ -135,9 +142,10 @@ class SettingsService:
                         output_device = output_settings
                         device = sd.query_devices(output_settings)
                         if not device["max_output_channels"]:
-                            self.printr.print(
-                                "Configured output device is not an output device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                            )
+                            if write:
+                                self.printr.print(
+                                    "Configured output device is not an output device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                )
                             output_device = None
                         else:
                             output_name = sd.query_devices()[output_settings]["name"]
@@ -145,29 +153,33 @@ class SettingsService:
                             output_settings = AudioDeviceSettings(
                                 name=output_name, hostapi=output_hostapi
                             )
-                            self.printr.print(
-                                f"Using output device '{output_name}'.", color=LogType.INFO, server_only=True
-                            )
+                            if write:
+                                self.printr.print(
+                                    f"Using output device '{output_name}'.", color=LogType.INFO, server_only=True
+                                )
                     else:
-                        self.printr.print(
-                            "Configured output device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                        )
+                        if write:
+                            self.printr.print(
+                                "Configured output device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                            )
                         output_device = None
                 # check if instance of AudioDeviceSettings
                 elif isinstance(output_settings, AudioDeviceSettings):
                     # get id with name and hostapi
                     for device in sd.query_devices():
                         if device["max_output_channels"] > 0 and device["name"] == output_settings.name and device["hostapi"] == output_settings.hostapi:
-                            self.printr.print(
-                                f"Using output device '{device["name"]}'.", color=LogType.INFO, server_only=True
-                            )
+                            if write:
+                                self.printr.print(
+                                    f"Using output device '{device["name"]}'.", color=LogType.INFO, server_only=True
+                                )
                             output_device = device["index"]
                             break
                     if output_device is None:
-                        self.printr.print(
-                            f"Configured audio output device '{output_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
-                        )
-            else:
+                        if write:
+                            self.printr.print(
+                                f"Configured audio output device '{output_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                            )
+            elif write:
                 self.printr.print(
                     "No output device set. Using default.", color=LogType.INFO, server_only=True
                 )

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -68,7 +68,9 @@ class SettingsService:
     # GET /settings
     def get_settings(self):
         config = self.config_manager.settings_config
-        config.audio = self.get_audio_settings_indexed(not self.converted_audio_settings)
+        config.audio = self.get_audio_settings_indexed(
+            not self.converted_audio_settings
+        )
         self.converted_audio_settings = True
         return config
 
@@ -76,8 +78,12 @@ class SettingsService:
         input_device = None
         output_device = None
         if self.config_manager.settings_config.audio:
-            input_settings_orig = input_settings = self.config_manager.settings_config.audio.input
-            output_settings_orig = output_settings = self.config_manager.settings_config.audio.output
+            input_settings_orig = input_settings = (
+                self.config_manager.settings_config.audio.input
+            )
+            output_settings_orig = output_settings = (
+                self.config_manager.settings_config.audio.output
+            )
 
             # check input
             if input_settings is not None:
@@ -92,43 +98,62 @@ class SettingsService:
                         if not device["max_input_channels"]:
                             if write:
                                 self.printr.print(
-                                    "Configured input device is not an input device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                    "Configured input device is not an input device. Using default.",
+                                    toast=ToastType.NORMAL,
+                                    color=LogType.WARNING,
                                 )
                             input_device = None
                         else:
                             input_name = sd.query_devices()[input_settings]["name"]
-                            input_hostapi = sd.query_devices()[input_settings]["hostapi"]
+                            input_hostapi = sd.query_devices()[input_settings][
+                                "hostapi"
+                            ]
                             input_settings = AudioDeviceSettings(
                                 name=input_name, hostapi=input_hostapi
                             )
                             if write:
                                 self.printr.print(
-                                    f"Using input device '{input_name}'.", color=LogType.INFO, server_only=True
+                                    f"Using input device '{input_name}'.",
+                                    color=LogType.INFO,
+                                    server_only=True,
                                 )
                     else:
                         if write:
                             self.printr.print(
-                                "Configured input device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                "Configured input device not found. Using default.",
+                                toast=ToastType.NORMAL,
+                                color=LogType.WARNING,
                             )
                         input_device = None
                 elif isinstance(input_settings, AudioDeviceSettings):
                     # get id with name and hostapi
                     for device in sd.query_devices():
-                        if device["max_input_channels"] > 0 and device["name"] == input_settings.name and device["hostapi"] == input_settings.hostapi:
+                        if (
+                            device["max_input_channels"] > 0
+                            and device["name"] == input_settings.name
+                            and device["hostapi"] == input_settings.hostapi
+                        ):
                             if write:
+                                device_name = device["name"]
                                 self.printr.print(
-                                    f"Using input device '{device["name"]}'.", color=LogType.INFO, server_only=True
+                                    f"Using input device '{device_name}'.",
+                                    color=LogType.INFO,
+                                    server_only=True,
                                 )
                             input_device = device["index"]
                             break
                     if input_device is None:
                         if write:
                             self.printr.print(
-                                f"Configured input device '{input_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                f"Configured input device '{input_settings.name}' not found. Using default.",
+                                toast=ToastType.NORMAL,
+                                color=LogType.WARNING,
                             )
             elif write:
                 self.printr.print(
-                    "No input device set. Using default.", color=LogType.INFO, server_only=True
+                    "No input device set. Using default.",
+                    color=LogType.INFO,
+                    server_only=True,
                 )
 
             # check output
@@ -144,49 +169,73 @@ class SettingsService:
                         if not device["max_output_channels"]:
                             if write:
                                 self.printr.print(
-                                    "Configured output device is not an output device. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                    "Configured output device is not an output device. Using default.",
+                                    toast=ToastType.NORMAL,
+                                    color=LogType.WARNING,
                                 )
                             output_device = None
                         else:
                             output_name = sd.query_devices()[output_settings]["name"]
-                            output_hostapi = sd.query_devices()[output_settings]["hostapi"]
+                            output_hostapi = sd.query_devices()[output_settings][
+                                "hostapi"
+                            ]
                             output_settings = AudioDeviceSettings(
                                 name=output_name, hostapi=output_hostapi
                             )
                             if write:
                                 self.printr.print(
-                                    f"Using output device '{output_name}'.", color=LogType.INFO, server_only=True
+                                    f"Using output device '{output_name}'.",
+                                    color=LogType.INFO,
+                                    server_only=True,
                                 )
                     else:
                         if write:
                             self.printr.print(
-                                "Configured output device not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                "Configured output device not found. Using default.",
+                                toast=ToastType.NORMAL,
+                                color=LogType.WARNING,
                             )
                         output_device = None
                 # check if instance of AudioDeviceSettings
                 elif isinstance(output_settings, AudioDeviceSettings):
                     # get id with name and hostapi
                     for device in sd.query_devices():
-                        if device["max_output_channels"] > 0 and device["name"] == output_settings.name and device["hostapi"] == output_settings.hostapi:
+                        if (
+                            device["max_output_channels"] > 0
+                            and device["name"] == output_settings.name
+                            and device["hostapi"] == output_settings.hostapi
+                        ):
                             if write:
+                                device_name = device["name"]
                                 self.printr.print(
-                                    f"Using output device '{device["name"]}'.", color=LogType.INFO, server_only=True
+                                    f"Using output device '{device_name}'.",
+                                    color=LogType.INFO,
+                                    server_only=True,
                                 )
                             output_device = device["index"]
                             break
                     if output_device is None:
                         if write:
                             self.printr.print(
-                                f"Configured audio output device '{output_settings.name}' not found. Using default.", toast=ToastType.NORMAL, color=LogType.WARNING
+                                f"Configured audio output device '{output_settings.name}' not found. Using default.",
+                                toast=ToastType.NORMAL,
+                                color=LogType.WARNING,
                             )
             elif write:
                 self.printr.print(
-                    "No output device set. Using default.", color=LogType.INFO, server_only=True
+                    "No output device set. Using default.",
+                    color=LogType.INFO,
+                    server_only=True,
                 )
 
             # overwrite settings with new structure, if needed
-            if write and (input_settings_orig != input_settings or output_settings_orig != output_settings):
-                self.config_manager.settings_config.audio = AudioSettings(input=input_settings, output=output_settings)
+            if write and (
+                input_settings_orig != input_settings
+                or output_settings_orig != output_settings
+            ):
+                self.config_manager.settings_config.audio = AudioSettings(
+                    input=input_settings, output=output_settings
+                )
                 self.config_manager.save_settings_config()
                 print("Audio settings updated.")
         return AudioSettings(input=input_device, output=output_device)

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -224,9 +224,9 @@ class SettingsService:
                 "Audio devices updated.", toast=ToastType.NORMAL, color=LogType.POSITIVE
             )
             await self.settings_events.publish(
-                "audio_devices_changed", (output_device, input_device)
+                "audio_devices_changed", (input_device, output_device)
             )
-        return output_device, input_device
+        return input_device, output_device
 
     # POST /settings/voice-activation
     async def set_voice_activation(self, is_enabled: bool):

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -142,9 +142,7 @@ class WingmanCore(WebSocketUser):
         )
 
         if self.settings_service.settings.audio:
-            input_device = self.settings_service.settings.audio.input
-            output_device = self.settings_service.settings.audio.output
-            sd.default.device = (input_device, output_device)
+            sd.default.device = [self.settings_service.settings.audio.input, self.settings_service.settings.audio.output]
             self.audio_recorder.update_input_stream()
 
     async def startup(self):


### PR DESCRIPTION
This PR changes how audio settings are saved.
From this
```
audio:
  input: 1
  output: 13
```

To this
```
audio:
  input:
    hostapi: 0
    name: 'SteelSeries Sonar - Microphone '
  output:
    hostapi: 0
    name: Name does not exist
```

Its also compatible with the old style and will rewrite it on first launch.
If no audio device setting is set up or the configured one is not found, system default will be used.

And there are also additional outputs at the start.
On server, input and output will always be printed out, like this:
![image](https://github.com/ShipBit/wingman-ai/assets/44277746/b6cd99c4-ced6-446e-8c72-5d0d99797326)

And the client only shows the warnings, like this:
![image](https://github.com/ShipBit/wingman-ai/assets/44277746/6e882b43-b1f2-4901-af9a-9edbc9182ca8)

This should help to understand automated changes.