### PR TITLE
Alt gr fix

### DIFF
--- a/keyboard/keyboard/_winkeyboard.py
+++ b/keyboard/keyboard/_winkeyboard.py
@@ -377,7 +377,8 @@ def _setup_name_tables():
                         # Remember the "id" of the name, as the first techniques
                         # have better results and therefore priority.
                         for i, name in enumerate(map(normalize_name, names + lowercase_names)):
-                            from_name[name].append((i, entry))
+                            if name != "alt gr": # alt gr gets added manually later
+                                from_name[name].append((i, entry))
 
         # TODO: single quotes on US INTL is returning the dead key (?), and therefore
         # not typing properly.


### PR DESCRIPTION
Just removed alt gr from the automated scan code mapping, as it is already mapped to scan code 541 manually later on.

This should prevent the default command "Flight Ready" with hotkey "alt gr" to get mapped to scan code "56", which is left alt, as the extended flag, which would prevent that, in the `map_name` function is not used at all.

But I have no idea why this has become an issue once more. 🤷‍♂️