### PR TITLE
fix hotkey detection with wingmen without hotkey

### DIFF
--- a/wingman_core.py
+++ b/wingman_core.py
@@ -186,7 +186,7 @@ class WingmanCore(WebSocketUser):
             wingman = None
             if key:
                 for potential_wingman in self.tower.wingmen:
-                    if self.is_hotkey_pressed(potential_wingman.get_record_key()):
+                    if potential_wingman.get_record_key() and self.is_hotkey_pressed(potential_wingman.get_record_key()):
                         wingman = potential_wingman
             elif button:
                 wingman = self.tower.get_wingman_from_mouse(button)


### PR DESCRIPTION
What the title says.
Very simple adjustment to not check wingmen on key presses, that do not have a hotkey assigned to them.
This check was causing an error before, if not hotkey was set hot at least one wingman.

Reported by ManteMcFly on Discord:
https://discord.com/channels/1173573578604687360/1242028956132179978