### PR TITLE
moving thread generation from skills to skill base for cleaner code

### DIFF
--- a/skills/uexcorp/main.py
+++ b/skills/uexcorp/main.py
@@ -384,21 +384,15 @@ class UEXCorp(Skill):
                     ):
                         tradeport["id_planet"] = ""
 
-        def _load_data(callback=None):
-            async def _actual_loading(callback=None):
-                await _load_from_cache()
-                await _load_missing_data()
-                await self._save_to_cachefile()
+        async def _load_data(callback=None):
+            await _load_from_cache()
+            await _load_missing_data()
+            await self._save_to_cachefile()
 
-                if callback:
-                    await callback()
+            if callback:
+                await callback()
 
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            new_loop.run_until_complete(_actual_loading(callback))
-            new_loop.close()
-
-        threading.Thread(target=_load_data, args=(callback,)).start()
+        self.threaded_execution(_load_data, callback)
 
     async def _save_to_cachefile(self) -> None:
         if (

--- a/skills/voice_changer/main.py
+++ b/skills/voice_changer/main.py
@@ -1,6 +1,4 @@
 import time
-import asyncio
-import threading
 from random import randrange
 from typing import TYPE_CHECKING
 from api.interface import (
@@ -241,7 +239,7 @@ class VoiceChanger(Skill):
 
         #prepare first personality
         if self.context_generation:
-            await self._generate_new_context_threaded()
+            self.threaded_execution(self._generate_new_context)
 
         return errors
 
@@ -337,21 +335,9 @@ class VoiceChanger(Skill):
         self.context_personality = self.context_personality_next
         self.context_personality_next = ""
 
-        await self._generate_new_context_threaded()
+        self.threaded_execution(self._generate_new_context)
 
         return "Switched personality context."
-
-    async def _generate_new_context_threaded(self):
-        def generate_next_context():
-            async def _actual_generating():
-                await self._generate_new_context()
-
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            new_loop.run_until_complete(_actual_generating())
-            new_loop.close()
-
-        threading.Thread(target=generate_next_context, args=()).start()
 
     async def _generate_new_context(self):
         messages = [

--- a/templates/skills/uexcorp/main.py
+++ b/templates/skills/uexcorp/main.py
@@ -384,21 +384,15 @@ class UEXCorp(Skill):
                     ):
                         tradeport["id_planet"] = ""
 
-        def _load_data(callback=None):
-            async def _actual_loading(callback=None):
-                await _load_from_cache()
-                await _load_missing_data()
-                await self._save_to_cachefile()
+        async def _load_data(callback=None):
+            await _load_from_cache()
+            await _load_missing_data()
+            await self._save_to_cachefile()
 
-                if callback:
-                    await callback()
+            if callback:
+                await callback()
 
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            new_loop.run_until_complete(_actual_loading(callback))
-            new_loop.close()
-
-        threading.Thread(target=_load_data, args=(callback,)).start()
+        self.threaded_execution(_load_data, callback)
 
     async def _save_to_cachefile(self) -> None:
         if (

--- a/templates/skills/voice_changer/main.py
+++ b/templates/skills/voice_changer/main.py
@@ -1,6 +1,4 @@
 import time
-import asyncio
-import threading
 from random import randrange
 from typing import TYPE_CHECKING
 from api.interface import (
@@ -241,7 +239,7 @@ class VoiceChanger(Skill):
 
         #prepare first personality
         if self.context_generation:
-            await self._generate_new_context_threaded()
+            self.threaded_execution(self._generate_new_context)
 
         return errors
 
@@ -337,21 +335,9 @@ class VoiceChanger(Skill):
         self.context_personality = self.context_personality_next
         self.context_personality_next = ""
 
-        await self._generate_new_context_threaded()
+        self.threaded_execution(self._generate_new_context)
 
         return "Switched personality context."
-
-    async def _generate_new_context_threaded(self):
-        def generate_next_context():
-            async def _actual_generating():
-                await self._generate_new_context()
-
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            new_loop.run_until_complete(_actual_generating())
-            new_loop.close()
-
-        threading.Thread(target=generate_next_context, args=()).start()
 
     async def _generate_new_context(self):
         messages = [


### PR DESCRIPTION
Moving thread execution from skills to skill base.
Gives cleaner code an a central position to adjust threading if ever needed.

Changelog:
- utilizing `threaded_execution` in uexcorp, voice changer and timer skills