### PR TITLE
making Wingman AI resistant to inaccessible mics

### DIFF
--- a/wingman_core.py
+++ b/wingman_core.py
@@ -355,6 +355,7 @@ class WingmanCore(WebSocketUser):
     async def on_audio_devices_changed(self, devices: tuple[int | None, int | None]):
         # devices: [output_device, input_device]
         sd.default.device = devices
+        self.audio_recorder.valid_mic = True # this allows a new error message
         self.audio_recorder.update_input_stream()
 
     async def set_voice_activation(self, is_enabled: bool):


### PR DESCRIPTION
As the title says.
Currently, when you start the wingman core but no mic is connected or a windows setting or anti-virus blocks mic access, the core will crash. Even the log shows no error.

As this happened multiple times now, I added a try catch block around the input streaming initializing with a handy error message.
This should prevent these unexpected untraceable crashes because of that in the future.