### PR TITLE
Distortion Flip to negatives to fix quality

### DIFF
--- a/services/sound_effects.py
+++ b/services/sound_effects.py
@@ -82,7 +82,7 @@ class SoundEffects(Enum):
     # Azure streaming workaround
     LOW_QUALITY_RADIO_GAIN_BOOST = Pedalboard(
         [
-            Distortion(drive_db=30),
+            Distortion(drive_db=-65),
             HighpassFilter(cutoff_frequency_hz=800),
             LowpassFilter(cutoff_frequency_hz=3400),
             Resample(target_sample_rate=8000),  # Lower resample rate for tinny effect
@@ -95,7 +95,7 @@ class SoundEffects(Enum):
     # Azure streaming workaround
     MEDIUM_QUALITY_RADIO_GAIN_BOOST = Pedalboard(
         [
-            Distortion(drive_db=15),
+            Distortion(drive_db=-74),
             HighpassFilter(cutoff_frequency_hz=300),
             LowpassFilter(cutoff_frequency_hz=5000),
             Resample(target_sample_rate=16000),


### PR DESCRIPTION
Distortion is -required- on this  pedalboard so we can not remove it.  However, due to how pedalboard does its effect, -100 is absolutely off, +100 is insane levels of on.  I have moved closer to -100 on both low and medium quality to keep the base effect but make it less severe.
