### PR TITLE
Provide support to snap applications

### DIFF
--- a/skills/control_windows/default_config.yaml
+++ b/skills/control_windows/default_config.yaml
@@ -26,4 +26,4 @@ examples:
       en: (closes the Notepad application)
       de: (schließt die Notepad Anwendung)
 prompt: |
-  You can also control Windows Functions, like opening and closing applications.
+  You can also control Windows Functions, like opening, closing, moving, and listing active applications.

--- a/skills/control_windows/main.py
+++ b/skills/control_windows/main.py
@@ -154,6 +154,20 @@ class ControlWindows(Skill):
         # If no windows found, return false
         return False
 
+    async def list_applications(self):
+        window_titles = gw.getAllTitles()
+        if window_titles:
+            titles_as_string = ", ".join(window_titles)
+            response = f"List of all application window titles found: {titles_as_string}."
+            if self.settings.debug_mode:
+                self.start_execution_benchmark()
+                await self.printr.print_async(
+                    f"list_applications command found these applications: {titles_as_string}",
+                    color=LogType.INFO,
+                )
+            return response
+        return False
+
     def get_tools(self) -> list[tuple[str, dict]]:
         tools = [
             (
@@ -162,7 +176,7 @@ class ControlWindows(Skill):
                     "type": "function",
                     "function": {
                         "name": "control_windows_functions",
-                        "description": "Control Windows Functions, like opening, closing, and moving applications.",
+                        "description": "Control Windows Functions, like opening, closing, listing, and moving applications.",
                         "parameters": {
                             "type": "object",
                             "properties": {
@@ -180,6 +194,7 @@ class ControlWindows(Skill):
                                         "snap_right",
                                         "snap_top",
                                         "snap_bottom",
+                                        "list_applications",
                                     ],
                                 },
                                 "parameter": {
@@ -234,6 +249,12 @@ class ControlWindows(Skill):
                 else:
                     function_response = "There was a problem moving that application. The application may not support moving it through automation."
 
+            elif "list" in parameters["command"].lower():
+                apps_listed = await self.list_applications()
+                if apps_listed:
+                    function_response = apps_listed
+                else:
+                    function_response = "There was a problem getting your list of applications."
             else:
                 command = parameters["command"]
                 app_minimize = self.execute_ui_command(parameter, command)

--- a/skills/control_windows/main.py
+++ b/skills/control_windows/main.py
@@ -11,6 +11,7 @@ from api.interface import (
 )
 from api.enums import LogType
 from skills.skill_base import Skill
+import mouse.mouse as mouse
 
 if TYPE_CHECKING:
     from wingmen.wingman import Wingman
@@ -172,6 +173,25 @@ class ControlWindows(Skill):
                         )
                     # Check if resize and move command really worked, if not return false so wingmanai does not tell user command was successful when it was not
                     if (monitor_width, monitor_height) == window.size:
+                        # Try last ditch manual move if moving to left or right
+                        if "left" in command:
+                            mouse.move(int(monitor_width * 0.5), 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.press(button="left")
+                            mouse.move(20, 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.release(button="left")
+                            return True
+
+                        elif "right" in command:
+                            mouse.move(int(monitor_width * 0.5), 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.press(button="left")
+                            mouse.move(monitor_width - 20, 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.release(button="left")
+                            return True
+                        # Return False as failed if could not move through any method
                         return False
                     return True
 

--- a/templates/skills/control_windows/default_config.yaml
+++ b/templates/skills/control_windows/default_config.yaml
@@ -26,4 +26,4 @@ examples:
       en: (closes the Notepad application)
       de: (schließt die Notepad Anwendung)
 prompt: |
-  You can also control Windows Functions, like opening and closing applications.
+  You can also control Windows Functions, like opening, closing, moving, and listing active applications.

--- a/templates/skills/control_windows/main.py
+++ b/templates/skills/control_windows/main.py
@@ -154,6 +154,20 @@ class ControlWindows(Skill):
         # If no windows found, return false
         return False
 
+    async def list_applications(self):
+        window_titles = gw.getAllTitles()
+        if window_titles:
+            titles_as_string = ", ".join(window_titles)
+            response = f"List of all application window titles found: {titles_as_string}."
+            if self.settings.debug_mode:
+                self.start_execution_benchmark()
+                await self.printr.print_async(
+                    f"list_applications command found these applications: {titles_as_string}",
+                    color=LogType.INFO,
+                )
+            return response
+        return False
+
     def get_tools(self) -> list[tuple[str, dict]]:
         tools = [
             (
@@ -162,7 +176,7 @@ class ControlWindows(Skill):
                     "type": "function",
                     "function": {
                         "name": "control_windows_functions",
-                        "description": "Control Windows Functions, like opening, closing, and moving applications.",
+                        "description": "Control Windows Functions, like opening, closing, listing, and moving applications.",
                         "parameters": {
                             "type": "object",
                             "properties": {
@@ -180,6 +194,7 @@ class ControlWindows(Skill):
                                         "snap_right",
                                         "snap_top",
                                         "snap_bottom",
+                                        "list_applications",
                                     ],
                                 },
                                 "parameter": {
@@ -234,6 +249,12 @@ class ControlWindows(Skill):
                 else:
                     function_response = "There was a problem moving that application. The application may not support moving it through automation."
 
+            elif "list" in parameters["command"].lower():
+                apps_listed = await self.list_applications()
+                if apps_listed:
+                    function_response = apps_listed
+                else:
+                    function_response = "There was a problem getting your list of applications."
             else:
                 command = parameters["command"]
                 app_minimize = self.execute_ui_command(parameter, command)

--- a/templates/skills/control_windows/main.py
+++ b/templates/skills/control_windows/main.py
@@ -11,6 +11,7 @@ from api.interface import (
 )
 from api.enums import LogType
 from skills.skill_base import Skill
+import mouse.mouse as mouse
 
 if TYPE_CHECKING:
     from wingmen.wingman import Wingman
@@ -172,6 +173,25 @@ class ControlWindows(Skill):
                         )
                     # Check if resize and move command really worked, if not return false so wingmanai does not tell user command was successful when it was not
                     if (monitor_width, monitor_height) == window.size:
+                        # Try last ditch manual move if moving to left or right
+                        if "left" in command:
+                            mouse.move(int(monitor_width * 0.5), 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.press(button="left")
+                            mouse.move(20, 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.release(button="left")
+                            return True
+
+                        elif "right" in command:
+                            mouse.move(int(monitor_width * 0.5), 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.press(button="left")
+                            mouse.move(monitor_width - 20, 10, duration=1.0)
+                            time.sleep(0.1)
+                            mouse.release(button="left")
+                            return True
+                        # Return False as failed if could not move through any method
                         return False
                     return True
 


### PR DESCRIPTION
not all applications support this but the ones that do can be snapped to the top, left, right and bottom of user screen

edge and chrome do not support this, but programs like powershell, notepad++ do

add debug logging and more try/except statements so users can figure out why sometimes things don't work

also list open applications, that may help wingman ai execute commands on problematic apps by ensuring the proper title is used

Note, with microsoft edge, sometimes once it is open, the window displays something like "Meta AI and 14 more pages - Personal - Microsoft\u200b Edge" as the title, and this messes up further commands with Edge, may want to also consider somehow stripping special characters like that to increase useablity.  Right now this just has a specific hack for Edge and the known \u200b issue.

MetaAI indicates the following: 

```
Yes, there are other special Unicode characters that might be invisible or affect string processing. Here are a few examples:
\u200e : Left-to-Right Mark (LRM)
\u200f : Right-to-Left Mark (RLM)
\u202a : Left-to-Right Embedding (LRE)
\u202b : Right-to-Left Embedding (RLE)
\u202c : Pop Directional Formatting (PDF)
\u2060 : Word Joiner (WJ)
\u2061 : Invisible Application-Defined (IAD)
\u2062 : Invisible Times (IT)
\u2063 : Invisible Separator (IS)
\uFEFF : Zero-Width No-Break Space (ZWNBSP)
```


