### PR TITLE
adding load (prepare) and unload events for skills

### DIFF
--- a/skills/skill_base.py
+++ b/skills/skill_base.py
@@ -36,6 +36,14 @@ class Skill:
     async def validate(self) -> list[WingmanInitializationError]:
         """Validates the skill configuration."""
         return []
+    
+    async def unload(self) -> None:
+        """Unload the skill. Use this hook to clear background tasks, etc."""
+        pass
+
+    async def prepare(self) -> None:
+        """Prepare the skill. Use this hook to initialize background tasks, etc."""
+        pass
 
     def get_tools(self) -> list[tuple[str, dict]]:
         """Returns a list of tools available in the skill."""

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -165,7 +165,16 @@ class WingmanCore(WebSocketUser):
         if self.settings_service.settings.voice_activation.enabled:
             await self.set_voice_activation(is_enabled=True)
 
+    async def unload_tower(self):
+        if self.tower:
+            for wingman in self.tower.wingmen:
+                for skill in wingman.skills:
+                    await skill.unload()
+                await wingman.unload()
+            self.tower = None
+
     async def initialize_tower(self, config_dir_info: ConfigWithDirInfo):
+        await self.unload_tower()
         self.tower = Tower(
             config=config_dir_info.config, audio_player=self.audio_player
         )

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -136,6 +136,9 @@ class Wingman:
 
         You can override it if you need to load async data from an API or file."""
 
+    async def unload(self):
+        """This method is called when the Wingman is unloaded by Tower. You can override it if you need to clean up resources."""
+
     async def init_skills(self) -> list[WingmanInitializationError]:
         """This method is called only once when the Wingman is instantiated by Tower.
         It is run AFTER validate() so you can access validated params safely here.
@@ -163,6 +166,7 @@ class Wingman:
                     if len(errors) == 0:
                         self.skills.append(skill)
                         await self.prepare_skill(skill)
+                        await skill.prepare()
                         printr.print(
                             f"Skill '{skill_config.name}' loaded successfully.",
                             color=LogType.INFO,


### PR DESCRIPTION
Adding load (prepare) and unload event hooks for skills.
This is needed to allow skills to end background tasks, if they are no longer active.

Specifically for these skills:
- radio chatter
- voice changer
- timer