### PR TITLE
Fix VA mic selection

### DIFF
--- a/services/audio_recorder.py
+++ b/services/audio_recorder.py
@@ -55,11 +55,14 @@ class AudioRecorder:
             self.recstream.close()
 
         try:
-            # throw exception to test
             self.recstream = sounddevice.InputStream(
                 callback=self.__handle_input_stream,
                 channels=self.channels,
                 samplerate=self.samplerate,
+            )
+            self.microphone = sr.Microphone(
+                sample_rate=self.samplerate,
+                device_index=self.recstream.device
             )
             return True
         except Exception:

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -89,13 +89,13 @@ class SettingsService:
         if (
             settings.voice_activation.energy_threshold
             != old.voice_activation.energy_threshold
+            or settings.voice_activation.stt_provider
+            != old.voice_activation.stt_provider
         ):
             await self.settings_events.publish(
-                "va_treshold_changed", settings.voice_activation.energy_threshold
+                "va_settings_changed", settings.voice_activation
             )
-            self.printr.print(
-                "Voice Activation energy threshold changed.", server_only=True
-            )
+            self.printr.print("Voice Activation settings changed.", server_only=True)
 
         # rest
         self.config_manager.settings_config.wingman_pro = settings.wingman_pro

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -19,6 +19,7 @@ from api.interface import (
     AudioDevice,
     AzureSttConfig,
     ConfigWithDirInfo,
+    VoiceActivationSettings,
     WingmanInitializationError,
 )
 from providers.open_ai import OpenAi
@@ -459,7 +460,7 @@ class WingmanCore(WebSocketUser):
             callback, wingman_name = await self.event_queue.get()
             await callback(wingman_name)
 
-    def on_va_settings_changed(self, _va_energy_threshold: float):
+    def on_va_settings_changed(self, _va_settings: VoiceActivationSettings):
         # restart VA with new settings
         if self.is_listening:
             self.start_voice_recognition(mute=True)

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -142,7 +142,7 @@ class WingmanCore(WebSocketUser):
             "voice_activation_changed", self.set_voice_activation
         )
         self.settings_service.settings_events.subscribe(
-            "va_treshold_changed", self.on_va_treshold_changed
+            "va_settings_changed", self.on_va_settings_changed
         )
 
         self.voice_service = VoiceService(
@@ -369,6 +369,9 @@ class WingmanCore(WebSocketUser):
         sd.default.device = devices
         self.audio_recorder.valid_mic = True  # this allows a new error message
         self.audio_recorder.update_input_stream()
+        if self.is_listening:
+            self.start_voice_recognition(mute=True)
+            self.start_voice_recognition(mute=False)
 
     async def set_voice_activation(self, is_enabled: bool):
         if is_enabled:
@@ -456,7 +459,7 @@ class WingmanCore(WebSocketUser):
             callback, wingman_name = await self.event_queue.get()
             await callback(wingman_name)
 
-    def on_va_treshold_changed(self, _va_energy_threshold: float):
+    def on_va_settings_changed(self, _va_energy_threshold: float):
         # restart VA with new settings
         if self.is_listening:
             self.start_voice_recognition(mute=True)


### PR DESCRIPTION
Added mic selection to `update_input_stream` function.
Added trigger to restart continuous listening on:
- audio device change
- va provider change

In total this should fix the issues where VA was using a different mic, than the PTT actions.

Info:
Azure is probably still an issue, as its using its own type of voice recognition.
But I'm not sure how to do the changes and testing them out, as I don't have direct Azure access.
This is probably also not a big issue right now, as I think that no one uses Azure right now.
But it should be added to some kind of known error/backlog list.