### PR TITLE
Autosave

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -39,6 +39,7 @@ class CommandTag(Enum):
     PLAYBACK_STARTED = "playback_started"
     PLAYBACK_STOPPED = "playback_stopped"
     UNAUTHORIZED = "unauthorized"
+    CONFIG_LOADED = "config_loaded"
 
 
 class CustomPropertyType(Enum):

--- a/services/config_manager.py
+++ b/services/config_manager.py
@@ -307,13 +307,6 @@ class ConfigManager:
         # not catching ValidationExceptions here, because we can't recover from it
         # TODO: Notify the client about the error somehow
 
-        self.printr.print(
-            f"Loaded and validated config: {config_dir.name}.",
-            color=LogType.INFO,
-            server_only=True,
-            source=LogSource.SYSTEM,
-            source_name=self.log_source_name,
-        )
         return config_dir, validated_config
 
     def rename_config(self, config_dir: ConfigDirInfo, new_name: str):

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -274,6 +274,7 @@ class ConfigService:
         wingman_config: WingmanConfig,
         silent: bool = False,
         validate: bool = False,
+        update_skills: bool = False,
     ):
         # update the wingman
         wingman = self.tower.get_wingman_by_name(wingman_file.name)
@@ -295,7 +296,9 @@ class ConfigService:
                 self.printr.toast_error(f"Wingman '{wingman_file.name}' not found.")
                 return
 
-        updated = await wingman.update_config(config=wingman_config, validate=validate)
+        updated = await wingman.update_config(
+            config=wingman_config, validate=validate, update_skills=update_skills
+        )
 
         if not updated:
             self.printr.toast_error(

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -259,12 +259,12 @@ class ConfigService:
             avatar=avatar,
         )
 
-        await self.save_wingman_config(
+        self.config_manager.save_wingman_config(
             config_dir=config_dir,
             wingman_file=wingman_file,
             wingman_config=wingman_config,
-            validate=True,
         )
+        await self.load_config(config_dir)
 
     # POST config/save-wingman
     async def save_wingman_config(

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -421,8 +421,6 @@ class ConfigService:
                 silent=True,
             )
 
-        await self.load_config(config_dir)
-
     # GET config/defaults
     async def get_defaults_config(self):
         return self.config_manager.load_defaults_config()
@@ -441,12 +439,12 @@ class ConfigService:
         if not saved:
             self.printr.toast_error("Failed to save default configuration.")
             return
+
+        message = "Default configuration changed."
+        if not silent:
+            self.printr.toast(message)
         else:
-            message = "Default configuration changed."
-            if not silent:
-                self.printr.toast(message)
-            else:
-                self.printr.print(text=message, server_only=True)
+            self.printr.print(text=message, server_only=True)
 
         # rewrite the Wingman config in each config dir, building a new diff to the the new defaults
         for config_dir in self.config_manager.get_config_dirs():

--- a/services/secret_keeper.py
+++ b/services/secret_keeper.py
@@ -3,10 +3,6 @@ from typing import Dict, Any
 import yaml
 from fastapi import APIRouter
 from api.commands import PromptSecretCommand
-from api.enums import (
-    LogType,
-    ToastType,
-)
 from services.config_manager import CONFIGS_DIR, SECRETS_FILE
 from services.file import get_writable_dir
 from services.websocket_user import WebSocketUser
@@ -109,7 +105,5 @@ class SecretKeeper(WebSocketUser):
         for key, value in secrets.items():
             self.secrets[key] = value
 
-        self.save()
-        await self.printr.print(
-            "Secrets updated.", toast=ToastType.NORMAL, color=LogType.POSITIVE
-        )
+        if self.save():
+            self.printr.print("Secrets updated.", server_only=True)

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -1,13 +1,12 @@
+from copy import deepcopy
 from typing import Optional
 from fastapi import APIRouter
 import sounddevice as sd
-from api.enums import LogType, ToastType, VoiceActivationSttProvider, WingmanProRegion
+from api.enums import LogType, ToastType
 from api.interface import (
     AudioSettings,
     AudioDeviceSettings,
-    AzureSttConfig,
     SettingsConfig,
-    WhispercppSttConfig,
 )
 from services.config_manager import ConfigManager
 from services.config_service import ConfigService
@@ -36,32 +35,8 @@ class SettingsService:
         )
         self.router.add_api_route(
             methods=["POST"],
-            path="/settings/audio-devices",
-            endpoint=self.set_audio_devices,
-            tags=tags,
-        )
-        self.router.add_api_route(
-            methods=["POST"],
-            path="/settings/voice-activation",
-            endpoint=self.set_voice_activation,
-            tags=tags,
-        )
-        self.router.add_api_route(
-            methods=["POST"],
-            path="/settings/mute-key",
-            endpoint=self.set_mute_key,
-            tags=tags,
-        )
-        self.router.add_api_route(
-            methods=["POST"],
-            path="/settings/debug-mode",
-            endpoint=self.set_debug_mode,
-            tags=tags,
-        )
-        self.router.add_api_route(
-            methods=["POST"],
-            path="/settings/wingman-pro",
-            endpoint=self.set_wingman_pro_settings,
+            path="/settings",
+            endpoint=self.save_settings,
             tags=tags,
         )
         self.router.add_api_route(
@@ -74,13 +49,114 @@ class SettingsService:
     # GET /settings
     def get_settings(self):
         config = self.config_manager.settings_config
-        config.audio = self.get_audio_settings_indexed(
+        config.audio = self._get_audio_settings_indexed(
             not self.converted_audio_settings
         )
         self.converted_audio_settings = True
         return config
 
-    def get_audio_settings_indexed(self, write: bool = True) -> AudioSettings:
+    # POST /settings
+    async def save_settings(self, settings: SettingsConfig):
+        old = deepcopy(self.config_manager.settings_config)
+
+        # audio devices
+        if (
+            (settings.audio is not None and old.audio is None)
+            or (settings.audio is None and old.audio is not None)
+            or (
+                settings.audio is not None
+                and old.audio is not None
+                and (
+                    settings.audio.input != old.audio.input
+                    or settings.audio.output != old.audio.output
+                )
+            )
+        ):
+            await self._set_audio_devices(settings.audio.input, settings.audio.output)
+
+        # voice activation
+        self.config_manager.settings_config.voice_activation = settings.voice_activation
+
+        if settings.voice_activation.enabled != old.voice_activation.enabled:
+            await self.settings_events.publish(
+                "voice_activation_changed", settings.voice_activation.enabled
+            )
+            self.printr.print(
+                f"Voice activation {'enabled' if settings.voice_activation.enabled else 'disabled'}.",
+                server_only=True,
+            )
+
+        if (
+            settings.voice_activation.energy_threshold
+            != old.voice_activation.energy_threshold
+        ):
+            await self.settings_events.publish(
+                "va_treshold_changed", settings.voice_activation.energy_threshold
+            )
+            self.printr.print(
+                "Voice Activation energy threshold changed.", server_only=True
+            )
+
+        # rest
+        self.config_manager.settings_config.wingman_pro = settings.wingman_pro
+        self.config_manager.settings_config.debug_mode = settings.debug_mode
+
+        # save the config file
+        self.config_manager.save_settings_config()
+
+        # update running wingmen
+        for wingman in self.config_service.tower.wingmen:
+            await wingman.update_settings(settings=self.config_manager.settings_config)
+
+    async def _set_audio_devices(
+        self, output_device: Optional[int] = None, input_device: Optional[int] = None
+    ):
+        input_settings = None
+        output_settings = None
+
+        if input_device is not None:
+            # get name and hostapi with id
+            device = sd.query_devices(input_device)
+            input_settings = AudioDeviceSettings(
+                name=device["name"],
+                hostapi=device["hostapi"],
+            )
+
+        if output_device is not None:
+            # get name and hostapi with id
+            device = sd.query_devices(output_device)
+            output_settings = AudioDeviceSettings(
+                name=device["name"],
+                hostapi=device["hostapi"],
+            )
+
+        self.config_manager.settings_config.audio = AudioSettings(
+            input=input_settings,
+            output=output_settings,
+        )
+
+        await self.settings_events.publish(
+            "audio_devices_changed", (input_device, output_device)
+        )
+        self.printr.print("Audio devices changed.", server_only=True)
+
+    # POST /settings/default-provider
+    async def set_default_provider(self, provider: str, patch_existing_wingmen: bool):
+        if provider != "wingman_pro" and provider != "openai":
+            self.printr.toast_error(
+                "Only 'wingman_pro' and 'openai' are valid default providers for summarization, conversation, TTS and STT.",
+            )
+            return
+
+        config = deepcopy(self.config_manager.default_config)
+        config.features.conversation_provider = provider
+        config.features.summarize_provider = provider
+        config.features.tts_provider = provider
+        config.features.stt_provider = provider
+
+        await self.config_service.save_defaults_config(config=config, validate=True)
+
+    def _get_audio_settings_indexed(self, write: bool = True) -> AudioSettings:
         input_device = None
         output_device = None
         if self.config_manager.settings_config.audio:
@@ -249,157 +325,5 @@ class SettingsService:
                     input=input_settings, output=output_settings
                 )
                 self.config_manager.save_settings_config()
-                print("Audio settings updated.")
+                self.printr.print("Audio settings updated.", server_only=True)
         return AudioSettings(input=input_device, output=output_device)
-
-    # POST /settings/audio-devices
-    async def set_audio_devices(
-        self, output_device: Optional[int] = None, input_device: Optional[int] = None
-    ):
-        input_settings = None
-        output_settings = None
-
-        if input_device is not None:
-            # get name and hostapi with id
-            device = sd.query_devices(input_device)
-            input_settings = AudioDeviceSettings(
-                name=device["name"],
-                hostapi=device["hostapi"],
-            )
-
-        if output_device is not None:
-            # get name and hostapi with id
-            device = sd.query_devices(output_device)
-            output_settings = AudioDeviceSettings(
-                name=device["name"],
-                hostapi=device["hostapi"],
-            )
-
-        self.config_manager.settings_config.audio = AudioSettings(
-            input=input_settings,
-            output=output_settings,
-        )
-
-        if self.config_manager.save_settings_config():
-            await self.printr.print_async(
-                "Audio devices updated.", toast=ToastType.NORMAL, color=LogType.POSITIVE
-            )
-            await self.settings_events.publish(
-                "audio_devices_changed", (input_device, output_device)
-            )
-        return input_device, output_device
-
-    # POST /settings/voice-activation
-    async def set_voice_activation(self, is_enabled: bool):
-        self.config_manager.settings_config.voice_activation.enabled = is_enabled
-
-        if self.config_manager.save_settings_config():
-            await self.printr.print_async(
-                f"Voice activation {'enabled' if is_enabled else 'disabled'}.",
-                toast=ToastType.NORMAL,
-                color=LogType.POSITIVE,
-            )
-            await self.settings_events.publish("voice_activation_changed", is_enabled)
-
-    # POST /settings/mute-key
-    async def set_mute_key(self, key: str, keycodes: Optional[list[int]] = None):
-        self.config_manager.settings_config.voice_activation.mute_toggle_key = key
-        self.config_manager.settings_config.voice_activation.mute_toggle_key_codes = (
-            keycodes
-        )
-
-        if self.config_manager.save_settings_config():
-            await self.printr.print_async(
-                "Mute key saved.", toast=ToastType.NORMAL, color=LogType.POSITIVE
-            )
-
-    # POST /settings/debug-mode
-    async def set_debug_mode(self, debug_mode: bool):
-        self.config_manager.settings_config.debug_mode = debug_mode
-
-        if self.config_manager.save_settings_config():
-            await self.printr.print_async(
-                "Debug Mode saved.",
-                toast=ToastType.NORMAL,
-                color=LogType.POSITIVE,
-            )
-
-    # POST /settings/wingman-pro
-    async def set_wingman_pro_settings(
-        self,
-        base_url: str,
-        region: WingmanProRegion,
-        stt_provider: VoiceActivationSttProvider,
-        azure: AzureSttConfig,
-        whispercpp: WhispercppSttConfig,
-        va_energy_threshold: float,
-    ):
-        self.config_manager.settings_config.wingman_pro.base_url = base_url
-        self.config_manager.settings_config.wingman_pro.region = region
-
-        self.config_manager.settings_config.voice_activation.stt_provider = stt_provider
-        self.config_manager.settings_config.voice_activation.azure = azure
-        self.config_manager.settings_config.voice_activation.whispercpp = whispercpp
-
-        old_va_threshold = (
-            self.config_manager.settings_config.voice_activation.energy_threshold
-        )
-        self.config_manager.settings_config.voice_activation.energy_threshold = (
-            va_energy_threshold
-        )
-
-        if self.config_manager.save_settings_config():
-            await self.config_service.load_config()
-            await self.printr.print_async(
-                "Wingman Pro settings updated.",
-                toast=ToastType.NORMAL,
-                color=LogType.POSITIVE,
-            )
-            if old_va_threshold != va_energy_threshold:
-                await self.settings_events.publish(
-                    "va_treshold_changed", va_energy_threshold
-                )
-
-    # POST /settings/default-provider
-    async def set_default_provider(self, provider: str, patch_existing_wingmen: bool):
-        if provider != "wingman_pro" and provider != "openai":
-            self.printr.toast_error(
-                "Only 'wingman_pro' and 'openai' are valid default providers for summarization, conversation, TTS and STT.",
-            )
-            return
-
-        self.config_manager.default_config.features.conversation_provider = provider
-        self.config_manager.default_config.features.summarize_provider = provider
-        self.config_manager.default_config.features.tts_provider = provider
-        self.config_manager.default_config.features.stt_provider = provider
-
-        self.config_manager.save_defaults_config()
-
-        if patch_existing_wingmen:
-            config_dirs = self.config_service.get_config_dirs()
-            for config_dir in config_dirs.config_dirs:
-                wingman_config_files = (
-                    await self.config_service.get_wingmen_config_files(config_dir.name)
-                )
-                for wingman_config_file in wingman_config_files:
-                    wingman_config = self.config_manager.load_wingman_config(
-                        config_dir=config_dir, wingman_file=wingman_config_file
-                    )
-                    if wingman_config:
-                        wingman_config.features.conversation_provider = provider
-                        wingman_config.features.summarize_provider = provider
-                        wingman_config.features.tts_provider = provider
-                        wingman_config.features.stt_provider = provider
-
-                        self.config_manager.save_wingman_config(
-                            config_dir=config_dir,
-                            wingman_file=wingman_config_file,
-                            wingman_config=wingman_config,
-                        )
-        await self.config_service.load_config(self.config_service.current_config_dir)
-
-        await self.printr.print_async(
-            "Default providers updated.",
-            toast=ToastType.NORMAL,
-            color=LogType.POSITIVE,
-        )

--- a/services/tower.py
+++ b/services/tower.py
@@ -1,5 +1,10 @@
 from api.enums import LogSource, LogType, WingmanInitializationErrorType
-from api.interface import Config, SettingsConfig, WingmanInitializationError
+from api.interface import (
+    Config,
+    SettingsConfig,
+    WingmanConfig,
+    WingmanInitializationError,
+)
 from services.audio_player import AudioPlayer
 from services.module_manager import ModuleManager
 from services.printr import Printr
@@ -16,6 +21,7 @@ class Tower:
         self.config = config
         self.mouse_wingman_dict: dict[str, Wingman] = {}
         self.wingmen: list[Wingman] = []
+        self.disabled_wingmen: list[WingmanConfig] = []
         self.log_source_name = "Tower"
 
     async def instantiate_wingmen(self, settings: SettingsConfig):
@@ -26,6 +32,7 @@ class Tower:
 
         for wingman_name, wingman_config in self.config.wingmen.items():
             if wingman_config.disabled is True:
+                self.disabled_wingmen.append(wingman_config)
                 printr.print(
                     f"Skipped instantiating disabled wingman {wingman_config.name}.",
                     color=LogType.WARNING,
@@ -35,61 +42,12 @@ class Tower:
                 )
                 continue
 
-            wingman = None
-            try:
-                # it's a custom Wingman
-                if wingman_config.custom_class:
-                    wingman = ModuleManager.create_wingman_dynamically(
-                        name=wingman_name,
-                        config=wingman_config,
-                        settings=settings,
-                        audio_player=self.audio_player,
-                    )
-                else:
-                    wingman = OpenAiWingman(
-                        name=wingman_name,
-                        config=wingman_config,
-                        settings=settings,
-                        audio_player=self.audio_player,
-                    )
-            except FileNotFoundError as e:  # pylint: disable=broad-except
-                wingman_config.disabled = True
-                printr.print(
-                    f"Could not instantiate {wingman_name}:\n{str(e)}",
-                    color=LogType.WARNING,
-                    server_only=True,
-                    source_name=self.log_source_name,
-                    source=LogSource.SYSTEM,
-                )
-                continue
-            except Exception as e:  # pylint: disable=broad-except
-                wingman_config.disabled = True
-                # just in case we missed something
-                msg = str(e).strip() or type(e).__name__
-                errors.append(
-                    WingmanInitializationError(
-                        wingman_name=wingman_name,
-                        message=msg,
-                        error_type=WingmanInitializationErrorType.UNKNOWN,
-                    )
-                )
-                continue
-            else:
-                # additional validation check if no exception was raised
-                validation_errors = await wingman.validate()
-                errors.extend(validation_errors)
-
-                # init and validate skills
-                skill_errors = await wingman.init_skills()
-
-                if not errors or len(errors) == 0:
-                    await wingman.prepare()
-                    self.wingmen.append(wingman)
-
-                # Mouse
-                button = wingman.get_record_button()
-                if button:
-                    self.mouse_wingman_dict[button] = wingman
+            _wingman = await self.__instantiate_wingman(
+                wingman_name=wingman_name,
+                wingman_config=wingman_config,
+                settings=settings,
+                errors=errors,
+            )
 
         printr.print(
             f"Instantiated wingmen: {', '.join([w.name for w in self.wingmen])}.",
@@ -100,6 +58,71 @@ class Tower:
         )
         return errors
 
+    async def __instantiate_wingman(
+        self,
+        wingman_name: str,
+        wingman_config: WingmanConfig,
+        settings: SettingsConfig,
+        errors: list[WingmanInitializationError],
+    ):
+        wingman = None
+        try:
+            # it's a custom Wingman
+            if wingman_config.custom_class:
+                wingman = ModuleManager.create_wingman_dynamically(
+                    name=wingman_name,
+                    config=wingman_config,
+                    settings=settings,
+                    audio_player=self.audio_player,
+                )
+            else:
+                wingman = OpenAiWingman(
+                    name=wingman_name,
+                    config=wingman_config,
+                    settings=settings,
+                    audio_player=self.audio_player,
+                )
+        except FileNotFoundError as e:  # pylint: disable=broad-except
+            wingman_config.disabled = True
+            self.disabled_wingmen.append(wingman_config)
+            printr.print(
+                f"Could not instantiate {wingman_name}:\n{str(e)}",
+                color=LogType.WARNING,
+                server_only=True,
+                source_name=self.log_source_name,
+                source=LogSource.SYSTEM,
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            wingman_config.disabled = True
+            self.disabled_wingmen.append(wingman_config)
+            # just in case we missed something
+            msg = str(e).strip() or type(e).__name__
+            errors.append(
+                WingmanInitializationError(
+                    wingman_name=wingman_name,
+                    message=msg,
+                    error_type=WingmanInitializationErrorType.UNKNOWN,
+                )
+            )
+        else:
+            # additional validation check if no exception was raised
+            validation_errors = await wingman.validate()
+            errors.extend(validation_errors)
+
+            # init and validate skills
+            skill_errors = await wingman.init_skills()
+
+            if not errors or len(errors) == 0:
+                await wingman.prepare()
+                self.wingmen.append(wingman)
+
+            # Mouse
+            button = wingman.get_record_button()
+            if button:
+                self.mouse_wingman_dict[button] = wingman
+
+        return wingman
+
     def get_wingman_from_mouse(self, mouse: any) -> Wingman | None:  # type: ignore
         wingman = self.mouse_wingman_dict.get(mouse, None)
         return wingman
@@ -107,7 +130,7 @@ class Tower:
     def get_wingman_from_text(self, text: str) -> Wingman | None:
         for wingman in self.wingmen:
             # Check if a wingman name is in the text
-            if wingman.name.lower() in text.lower():
+            if wingman.config.name.lower() in text.lower():
                 return wingman
 
         # Check if there is a default wingman defined in the config
@@ -119,6 +142,55 @@ class Tower:
 
     def get_wingman_by_name(self, wingman_name: str):
         for wingman in self.wingmen:
-            if wingman.name == wingman_name:
+            if wingman.config.name == wingman_name:
                 return wingman
         return None
+
+    def get_disabled_wingman_by_name(self, wingman_name: str):
+        for wingman_config in self.disabled_wingmen:
+            if wingman_config.name == wingman_name:
+                return wingman_config
+        return None
+
+    async def enable_wingman(
+        self,
+        wingman_name: str,
+        settings: SettingsConfig,
+    ):
+        errors: list[WingmanInitializationError] = []
+        wingman_config = self.get_disabled_wingman_by_name(wingman_name)
+        if wingman_config:
+            wingman = await self.__instantiate_wingman(
+                wingman_name=wingman_name,
+                wingman_config=wingman_config,
+                settings=settings,
+                errors=errors,
+            )
+            if wingman:
+                wingman_config.disabled = False
+                self.disabled_wingmen.remove(wingman_config)
+                printr.print(
+                    f"Enabled wingman {wingman_name}.",
+                    color=LogType.INFO,
+                    server_only=True,
+                    source_name=self.log_source_name,
+                    source=LogSource.SYSTEM,
+                )
+                return True
+        return False
+
+    def disable_wingman(self, wingman_name: str):
+        for wingman in self.wingmen:
+            if wingman.name == wingman_name:
+                wingman.config.disabled = True
+                self.disabled_wingmen.append(wingman.config)
+                self.wingmen.remove(wingman)
+                printr.print(
+                    f"Disabled wingman {wingman_name}.",
+                    color=LogType.INFO,
+                    server_only=True,
+                    source_name=self.log_source_name,
+                    source=LogSource.SYSTEM,
+                )
+                return True
+        return False

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -172,6 +172,7 @@ class WingmanCore(WebSocketUser):
                     await skill.unload()
                 await wingman.unload()
             self.tower = None
+            self.config_service.set_tower(None)
 
     async def initialize_tower(self, config_dir_info: ConfigWithDirInfo):
         await self.unload_tower()
@@ -183,6 +184,8 @@ class WingmanCore(WebSocketUser):
         )
         for error in self.tower_errors:
             self.printr.toast_error(error.message)
+
+        self.config_service.set_tower(self.tower)
 
     def is_hotkey_pressed(self, hotkey: list[int] | str) -> bool:
         codes = []

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -128,72 +128,84 @@ class OpenAiWingman(Wingman):
         if provider_type == "openai":
             return any(
                 [
-                    self.tts_provider == TtsProvider.OPENAI,
-                    self.stt_provider == SttProvider.OPENAI,
-                    self.conversation_provider == ConversationProvider.OPENAI,
-                    self.summarize_provider == SummarizeProvider.OPENAI,
+                    self.config.features.tts_provider == TtsProvider.OPENAI,
+                    self.config.features.stt_provider == SttProvider.OPENAI,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.OPENAI,
+                    self.config.features.summarize_provider == SummarizeProvider.OPENAI,
                 ]
             )
         elif provider_type == "mistral":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.MISTRAL,
-                    self.summarize_provider == SummarizeProvider.MISTRAL,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.MISTRAL,
+                    self.config.features.summarize_provider
+                    == SummarizeProvider.MISTRAL,
                 ]
             )
         elif provider_type == "groq":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.GROQ,
-                    self.summarize_provider == SummarizeProvider.GROQ,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.GROQ,
+                    self.config.features.summarize_provider == SummarizeProvider.GROQ,
                 ]
             )
         elif provider_type == "google":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.GOOGLE,
-                    self.summarize_provider == SummarizeProvider.GOOGLE,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.GOOGLE,
+                    self.config.features.summarize_provider == SummarizeProvider.GOOGLE,
                 ]
             )
         elif provider_type == "openrouter":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.OPENROUTER,
-                    self.summarize_provider == SummarizeProvider.OPENROUTER,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.OPENROUTER,
+                    self.config.features.summarize_provider
+                    == SummarizeProvider.OPENROUTER,
                 ]
             )
         elif provider_type == "local_llm":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.LOCAL_LLM,
-                    self.summarize_provider == SummarizeProvider.LOCAL_LLM,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.LOCAL_LLM,
+                    self.config.features.summarize_provider
+                    == SummarizeProvider.LOCAL_LLM,
                 ]
             )
         elif provider_type == "azure":
             return any(
                 [
-                    self.tts_provider == TtsProvider.AZURE,
-                    self.stt_provider == SttProvider.AZURE,
-                    self.stt_provider == SttProvider.AZURE_SPEECH,
-                    self.conversation_provider == ConversationProvider.AZURE,
-                    self.summarize_provider == SummarizeProvider.AZURE,
+                    self.config.features.tts_provider == TtsProvider.AZURE,
+                    self.config.features.stt_provider == SttProvider.AZURE,
+                    self.config.features.stt_provider == SttProvider.AZURE_SPEECH,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.AZURE,
+                    self.config.features.summarize_provider == SummarizeProvider.AZURE,
                 ]
             )
         elif provider_type == "edge_tts":
-            return self.tts_provider == TtsProvider.EDGE_TTS
+            return self.config.features.tts_provider == TtsProvider.EDGE_TTS
         elif provider_type == "elevenlabs":
-            return self.tts_provider == TtsProvider.ELEVENLABS
+            return self.config.features.tts_provider == TtsProvider.ELEVENLABS
         elif provider_type == "xvasynth":
-            return self.tts_provider == TtsProvider.XVASYNTH
+            return self.config.features.tts_provider == TtsProvider.XVASYNTH
         elif provider_type == "whispercpp":
-            return self.stt_provider == SttProvider.WHISPERCPP
+            return self.config.features.stt_provider == SttProvider.WHISPERCPP
         elif provider_type == "wingman_pro":
             return any(
                 [
-                    self.conversation_provider == ConversationProvider.WINGMAN_PRO,
-                    self.summarize_provider == SummarizeProvider.WINGMAN_PRO,
-                    self.tts_provider == TtsProvider.WINGMAN_PRO,
-                    self.stt_provider == SttProvider.WINGMAN_PRO,
+                    self.config.features.conversation_provider
+                    == ConversationProvider.WINGMAN_PRO,
+                    self.config.features.summarize_provider
+                    == SummarizeProvider.WINGMAN_PRO,
+                    self.config.features.tts_provider == TtsProvider.WINGMAN_PRO,
+                    self.config.features.stt_provider == SttProvider.WINGMAN_PRO,
                 ]
             )
         return False
@@ -383,23 +395,23 @@ class OpenAiWingman(Wingman):
         """
         transcript = None
 
-        if self.stt_provider == SttProvider.AZURE:
+        if self.config.features.stt_provider == SttProvider.AZURE:
             transcript = self.openai_azure.transcribe_whisper(
                 filename=audio_input_wav,
                 api_key=self.azure_api_keys["whisper"],
                 config=self.config.azure.whisper,
             )
-        elif self.stt_provider == SttProvider.AZURE_SPEECH:
+        elif self.config.features.stt_provider == SttProvider.AZURE_SPEECH:
             transcript = self.openai_azure.transcribe_azure_speech(
                 filename=audio_input_wav,
                 api_key=self.azure_api_keys["tts"],
                 config=self.config.azure.stt,
             )
-        elif self.stt_provider == SttProvider.WHISPERCPP:
+        elif self.config.features.stt_provider == SttProvider.WHISPERCPP:
             transcript = self.whispercpp.transcribe(
                 filename=audio_input_wav, config=self.config.whispercpp
             )
-        elif self.stt_provider == SttProvider.WINGMAN_PRO:
+        elif self.config.features.stt_provider == SttProvider.WINGMAN_PRO:
             if self.config.wingman_pro.stt_provider == WingmanProSttProvider.WHISPER:
                 transcript = self.wingman_pro.transcribe_whisper(
                     filename=audio_input_wav
@@ -411,7 +423,7 @@ class OpenAiWingman(Wingman):
                 transcript = self.wingman_pro.transcribe_azure_speech(
                     filename=audio_input_wav, config=self.config.azure.stt
                 )
-        elif self.stt_provider == SttProvider.OPENAI:
+        elif self.config.features.stt_provider == SttProvider.OPENAI:
             transcript = self.openai.transcribe(filename=audio_input_wav)
 
         if not transcript:
@@ -810,7 +822,10 @@ class OpenAiWingman(Wingman):
         Generates an image from the provided text configured provider.
         """
 
-        if self.image_generation_provider == ImageGenerationProvider.WINGMAN_PRO:
+        if (
+            self.config.features.image_generation_provider
+            == ImageGenerationProvider.WINGMAN_PRO
+        ):
             return await self.wingman_pro.generate_image(text)
 
         return ""
@@ -820,50 +835,58 @@ class OpenAiWingman(Wingman):
         Perform the actual LLM call with the messages provided.
         """
 
-        if self.conversation_provider == ConversationProvider.AZURE:
+        if self.config.features.conversation_provider == ConversationProvider.AZURE:
             completion = self.openai_azure.ask(
                 messages=messages,
                 api_key=self.azure_api_keys["conversation"],
                 config=self.config.azure.conversation,
                 tools=tools,
             )
-        elif self.conversation_provider == ConversationProvider.OPENAI:
+        elif self.config.features.conversation_provider == ConversationProvider.OPENAI:
             completion = self.openai.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.openai.conversation_model.value,
             )
-        elif self.conversation_provider == ConversationProvider.MISTRAL:
+        elif self.config.features.conversation_provider == ConversationProvider.MISTRAL:
             completion = self.mistral.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.mistral.conversation_model.value,
             )
-        elif self.conversation_provider == ConversationProvider.GROQ:
+        elif self.config.features.conversation_provider == ConversationProvider.GROQ:
             completion = self.groq.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.groq.conversation_model.value,
             )
-        elif self.conversation_provider == ConversationProvider.GOOGLE:
+        elif self.config.features.conversation_provider == ConversationProvider.GOOGLE:
             completion = self.google.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.google.conversation_model.value,
             )
-        elif self.conversation_provider == ConversationProvider.OPENROUTER:
+        elif (
+            self.config.features.conversation_provider
+            == ConversationProvider.OPENROUTER
+        ):
             completion = self.openrouter.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.openrouter.conversation_model,
             )
-        elif self.conversation_provider == ConversationProvider.LOCAL_LLM:
+        elif (
+            self.config.features.conversation_provider == ConversationProvider.LOCAL_LLM
+        ):
             completion = self.local_llm.ask(
                 messages=messages,
                 tools=tools,
                 model=self.config.local_llm.conversation_model,
             )
-        elif self.conversation_provider == ConversationProvider.WINGMAN_PRO:
+        elif (
+            self.config.features.conversation_provider
+            == ConversationProvider.WINGMAN_PRO
+        ):
             completion = self.wingman_pro.ask(
                 messages=messages,
                 deployment=self.config.wingman_pro.conversation_deployment,
@@ -996,43 +1019,43 @@ class OpenAiWingman(Wingman):
 
         await self.add_context(messages)
 
-        if self.summarize_provider == SummarizeProvider.AZURE:
+        if self.config.features.summarize_provider == SummarizeProvider.AZURE:
             summarize_response = self.openai_azure.ask(
                 messages=messages,
                 api_key=self.azure_api_keys["summarize"],
                 config=self.config.azure.summarize,
             )
-        elif self.summarize_provider == SummarizeProvider.OPENAI:
+        elif self.config.features.summarize_provider == SummarizeProvider.OPENAI:
             summarize_response = self.openai.ask(
                 messages=self.messages,
                 model=self.config.openai.summarize_model.value,
             )
-        elif self.summarize_provider == SummarizeProvider.MISTRAL:
+        elif self.config.features.summarize_provider == SummarizeProvider.MISTRAL:
             summarize_response = self.mistral.ask(
                 messages=self.messages,
                 model=self.config.mistral.summarize_model.value,
             )
-        elif self.summarize_provider == SummarizeProvider.GROQ:
+        elif self.config.features.summarize_provider == SummarizeProvider.GROQ:
             summarize_response = self.groq.ask(
                 messages=self.messages,
                 model=self.config.groq.summarize_model.value,
             )
-        elif self.summarize_provider == SummarizeProvider.GOOGLE:
+        elif self.config.features.summarize_provider == SummarizeProvider.GOOGLE:
             summarize_response = self.google.ask(
                 messages=self.messages,
                 model=self.config.google.summarize_model.value,
             )
-        elif self.summarize_provider == SummarizeProvider.OPENROUTER:
+        elif self.config.features.summarize_provider == SummarizeProvider.OPENROUTER:
             summarize_response = self.openrouter.ask(
                 messages=self.messages,
                 model=self.config.openrouter.summarize_model,
             )
-        elif self.summarize_provider == SummarizeProvider.LOCAL_LLM:
+        elif self.config.features.summarize_provider == SummarizeProvider.LOCAL_LLM:
             summarize_response = self.local_llm.ask(
                 messages=self.messages,
                 model=self.config.local_llm.summarize_model,
             )
-        elif self.summarize_provider == SummarizeProvider.WINGMAN_PRO:
+        elif self.config.features.summarize_provider == SummarizeProvider.WINGMAN_PRO:
             summarize_response = self.wingman_pro.ask(
                 messages=messages,
                 deployment=self.config.wingman_pro.summarize_deployment,
@@ -1115,7 +1138,7 @@ class OpenAiWingman(Wingman):
 
         self.audio_player.set_volume(self.config.sound, volume)
 
-        if self.tts_provider == TtsProvider.EDGE_TTS:
+        if self.config.features.tts_provider == TtsProvider.EDGE_TTS:
             await self.edge_tts.play_audio(
                 text=text,
                 config=self.config.edge_tts,
@@ -1123,7 +1146,7 @@ class OpenAiWingman(Wingman):
                 audio_player=self.audio_player,
                 wingman_name=self.name,
             )
-        elif self.tts_provider == TtsProvider.ELEVENLABS:
+        elif self.config.features.tts_provider == TtsProvider.ELEVENLABS:
             await self.elevenlabs.play_audio(
                 text=text,
                 config=self.config.elevenlabs,
@@ -1132,7 +1155,7 @@ class OpenAiWingman(Wingman):
                 wingman_name=self.name,
                 stream=self.config.elevenlabs.output_streaming,
             )
-        elif self.tts_provider == TtsProvider.AZURE:
+        elif self.config.features.tts_provider == TtsProvider.AZURE:
             await self.openai_azure.play_audio(
                 text=text,
                 api_key=self.azure_api_keys["tts"],
@@ -1141,7 +1164,7 @@ class OpenAiWingman(Wingman):
                 audio_player=self.audio_player,
                 wingman_name=self.name,
             )
-        elif self.tts_provider == TtsProvider.XVASYNTH:
+        elif self.config.features.tts_provider == TtsProvider.XVASYNTH:
             await self.xvasynth.play_audio(
                 text=text,
                 config=self.config.xvasynth,
@@ -1149,7 +1172,7 @@ class OpenAiWingman(Wingman):
                 audio_player=self.audio_player,
                 wingman_name=self.name,
             )
-        elif self.tts_provider == TtsProvider.OPENAI:
+        elif self.config.features.tts_provider == TtsProvider.OPENAI:
             await self.openai.play_audio(
                 text=text,
                 voice=self.config.openai.tts_voice,
@@ -1157,7 +1180,7 @@ class OpenAiWingman(Wingman):
                 audio_player=self.audio_player,
                 wingman_name=self.name,
             )
-        elif self.tts_provider == TtsProvider.WINGMAN_PRO:
+        elif self.config.features.tts_provider == TtsProvider.WINGMAN_PRO:
             if self.config.wingman_pro.tts_provider == WingmanProTtsProvider.OPENAI:
                 await self.wingman_pro.generate_openai_speech(
                     text=text,
@@ -1175,7 +1198,9 @@ class OpenAiWingman(Wingman):
                     wingman_name=self.name,
                 )
         else:
-            printr.toast_error(f"Unsupported TTS provider: {self.tts_provider}")
+            printr.toast_error(
+                f"Unsupported TTS provider: {self.config.features.tts_provider}"
+            )
 
     async def _execute_command(self, command: dict) -> str:
         """Does what Wingman base does, but always returns "Ok" instead of a command response.

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -63,12 +63,6 @@ class Wingman:
         self.debug: bool = self.settings.debug_mode
         """If enabled, the Wingman will print more debug messages and benchmark results."""
 
-        self.tts_provider = self.config.features.tts_provider
-        self.stt_provider = self.config.features.stt_provider
-        self.conversation_provider = self.config.features.conversation_provider
-        self.summarize_provider = self.config.features.summarize_provider
-        self.image_generation_provider = self.config.features.image_generation_provider
-
         self.skills: list[Skill] = []
 
     def get_record_key(self) -> str | int:
@@ -336,7 +330,9 @@ class Wingman:
 
         return random.choice(command_responses)
 
-    async def _execute_instant_activation_command(self, transcript: str) -> list[CommandConfig] | None:
+    async def _execute_instant_activation_command(
+        self, transcript: str
+    ) -> list[CommandConfig] | None:
         """Uses a fuzzy string matching algorithm to match the transcript to a configured instant_activation command and executes it immediately.
 
         Args:
@@ -357,7 +353,9 @@ class Wingman:
                         commands_by_instant_activation[phrase.lower()] = [command]
 
         # find best matching phrase
-        phrase = difflib.get_close_matches(transcript.lower(), commands_by_instant_activation.keys(), n=1, cutoff=0.8)
+        phrase = difflib.get_close_matches(
+            transcript.lower(), commands_by_instant_activation.keys(), n=1, cutoff=0.8
+        )
 
         # if no phrase found, return None
         if not phrase:
@@ -485,6 +483,7 @@ class Wingman:
 
     def threaded_execution(self, function, *args) -> threading.Thread:
         """Execute a function in a separate thread."""
+
         def start_thread(function, *args):
             new_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(new_loop)

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import random
 import time
 import difflib
@@ -501,7 +502,7 @@ class Wingman:
     ):
         """Update the config of the Wingman. This method is called when the config of the Wingman has changed."""
         if validate:
-            old_config = WingmanConfig(**self.config.model_dump_json())
+            old_config = deepcopy(self.config)
 
         self.config = config
 

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -493,3 +493,19 @@ class Wingman:
         thread = threading.Thread(target=start_thread, args=(function, *args))
         thread.start()
         return thread
+
+    async def update_config(self, config: WingmanConfig, validate=False):
+        """Update the config of the Wingman. This method is called when the config of the Wingman has changed."""
+        if validate:
+            old_config = WingmanConfig(**self.config.model_dump_json())
+
+        self.config = config
+
+        if validate:
+            errors = await self.validate()
+
+            if errors and len(errors) > 0:
+                self.config = old_config
+                return False
+
+        return True


### PR DESCRIPTION
Core changes to allow (our client) to autosave configs and settings without having to reload the parent config all the time. This has several benefits:

- increased performance as loading a config is expensive
- way less conversation history resets
- no more save buttons 
- won screen space as we don't need the ActionBar anymore
- you can't forget to save

The changes have been implemented for:
- Wingman configs
- Default config
- Settings

Currently, only a couple of actions require a config reload and these are clearly propagated and displayed in the client: 
- renaming, adding and deleting configs
- renaming adding and deleting new Wingmen

# Important changes: 
- We should no longer cache the config and settings a Wingman receives on creation. Instead of assigning `this.stt_provider = config.features.stt_provider` in the ctor, access the config props directly when you need them.
- For skills I worked around this issue so that skills get re-initialized when needed, so that they re-cache with updated settings/configs
- If you make non-temporary changes to a Wingman config or Settings from a skill, use the appropriate service methods to make sure everything is updated properly.