### PR TITLE
Fixes bug where xvasynth would time out

### DIFF
--- a/providers/xvasynth.py
+++ b/providers/xvasynth.py
@@ -105,14 +105,19 @@ class XVASynth:
             "useSR": config.use_sr,
             "useCleanup": config.use_cleanup,
         }
-        response = requests.post(synthesize_url, json=data, timeout=10)
-        audio, sample_rate = audio_player.get_audio_from_file(file_path)
+        try:
+            response = requests.post(synthesize_url, json=data, timeout=30)
+            audio, sample_rate = audio_player.get_audio_from_file(file_path)
 
-        await audio_player.play_with_effects(
-            input_data=(audio, sample_rate),
-            config=sound_config,
-            wingman_name=wingman_name,
-        )
+            await audio_player.play_with_effects(
+                input_data=(audio, sample_rate),
+                config=sound_config,
+                wingman_name=wingman_name,
+            )
+        except:
+            self.printr.toast_error(
+                text="There was a problem synthesizing XVASynth voice line."
+            )
 
     def __check_if_running(self, url: str):
         # get base url from synthesize url in config


### PR DESCRIPTION
-extend timeout time; ten seconds was not enough to synthesize long paragraphs of text

-use try/except to catch errors so they don't freeze client

-overall xvasynth latency would benefit from a sentence by sentence streaming approach but that would likely make it extraordinarily complex to integrate with all the audio effects and other skills like radio chatter and voice changer, so leaving as-is for now.