### PR TITLE
bundle whispercpp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Build, Sign and Release
 
 on:
   push:
-    branches:
-      - 'feature/whispercpp-bundled'
+    tags:
+      - '*'
 
 jobs:
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Build, Sign and Release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'feature/whispercpp-bundled'
 
 jobs:
   build-windows:

--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,8 @@ cython_debug/
 .frontmatter/database/taxonomyDb.json
 frontmatter.json
 
+# Wingman AI:
 skills/**/dependencies
+whispercpp/
+whispercpp-cuda/
+whispercpp-models/

--- a/api/interface.py
+++ b/api/interface.py
@@ -116,17 +116,14 @@ class AudioSettings(BaseModel):
     output: Optional[int | AudioDeviceSettings] = None
 
 
-class WhispercppAutostartSettingsConfig(BaseModel):
-    whispercpp_exe_path: str
-    whispercpp_model_path: str
-
-
 class WhispercppSttConfig(BaseModel):
-    base_url: str
-    autostart: bool
-    autostart_settings: Optional[WhispercppAutostartSettingsConfig] = None
-    temperature: float
+    host: str
+    port: int
+    model: str
     language: str
+    temperature: float
+    translate_to_english: bool
+    use_cuda: bool
 
 
 class WhispercppTranscript(BaseModel):
@@ -332,6 +329,7 @@ class SoundConfig(BaseModel):
 
     volume: float
     """The volume for playback. 0.0 - 1.0"""
+
 
 class VoiceActivationSettings(BaseModel):
     """You can configure the voice activation here. If you don't want to use voice activation, just set 'enabled' to false."""

--- a/api/interface.py
+++ b/api/interface.py
@@ -116,14 +116,17 @@ class AudioSettings(BaseModel):
     output: Optional[int | AudioDeviceSettings] = None
 
 
-class WhispercppSttConfig(BaseModel):
+class WhispercppSettings(BaseModel):
     host: str
     port: int
     model: str
     language: str
-    temperature: float
     translate_to_english: bool
     use_cuda: bool
+
+
+class WhispercppSttConfig(BaseModel):
+    temperature: float
 
 
 class WhispercppTranscript(BaseModel):
@@ -348,7 +351,8 @@ class VoiceActivationSettings(BaseModel):
     stt_provider: VoiceActivationSttProvider
 
     azure: AzureSttConfig
-    whispercpp: WhispercppSttConfig
+    whispercpp: WhispercppSettings
+    whispercpp_config: WhispercppSttConfig
 
 
 class FeaturesConfig(BaseModel):

--- a/docs/develop-linux.md
+++ b/docs/develop-linux.md
@@ -1,15 +1,19 @@
 # Developing on Linux
+
 This will focus on debian-based distros (specifically Ubuntu), but just
-search what package names should be on your system. All python/pip 
+search what package names should be on your system. All python/pip
 commands are distro-independent.
 
 ## Pre-requisites
+
 Install required packages
+
 ```bash
 apt install python3-tk python3.10-venv portaudio
 ```
 
 ## Setup virtual environment (venv)
+
 ```bash
 python -m venv venv                 # create a virtual environment
 source venv/bin/activate            # activate the virtual environment
@@ -17,4 +21,9 @@ pip install -r requirements.txt     # install dependencies
 ```
 
 ## Setup Visual Studio Code
-[Same as MacOs.](https://github.com/ShipBit/wingman-ai/blob/main/docs/develop-macos.md#setup-visual-studio-code)
+
+[Same as MacOS](https://github.com/ShipBit/wingman-ai/blob/main/docs/develop-macos.md#setup-visual-studio-code)
+
+## Setup whispercpp
+
+[Same as MacOS](https://github.com/ShipBit/wingman-ai/blob/main/docs/develop-macos.md#setup-whispercpp)

--- a/docs/develop-macos.md
+++ b/docs/develop-macos.md
@@ -47,3 +47,15 @@ This process is not trusted! Input event monitoring will not be possible until i
 ```
 
 Go to `System Settings > Privacy & Security > Accessibility` and enable VSCode there, too.
+
+## Setup whispercpp
+
+The release version of Wingman AI bundles and uses whispercpp as local STT service and autostarts the service when neeed.
+Unfortunately, this only works on Windows. On MacOS, you have to start the service manually.
+
+- Download the latest stable MacOS release from the [whispercpp repository](https://github.com/ggerganov/whisper.cpp/releases) or build it from source
+- Download a model and copy it to `whispercpp/models` directory. We recommend to start with the `ggml-base.bin` model.
+- Start whispercpp on the host and port configured in Wingman AI. You can check the Wingman AI client and it will tell you the exact start cmd to execute.
+- Restart Wingman AI Core and it should connect to your running whispercpp instance.
+
+You obviously can't change the whispercpp settings in the Wingman AI UI on MacOS but the UI might give you a hint on how you can configure whispercpp server.

--- a/docs/develop-windows.md
+++ b/docs/develop-windows.md
@@ -51,3 +51,14 @@ Open `main.py` and run it. You should see the Wingman AI window should pop up. I
 - you have `main.py` active in the editor when you hit `F5` to run it
 
 We also suggest to install the recommended extensions if you haven't already. We're not forcing any strict syntactic coding styles right now but that might (have to) change in the future. If that will happen, `pylint` will certainly be used to enforce the style and it can help you with some basic stuff already if you aren't super familiar with Python (like us).
+
+## Setup whispercpp
+
+The release version of Wingman AI bundles and uses whispercpp as local STT service and autostarts the service when needed.
+The whispercpp binaries are bundled in the client for various reasons and we did not integrate them into Wingman AI Core.
+
+Here is how you can use the "autostart" functionality in Windows Dev mode (running from source):
+
+- Install the latest Wingman AI release version from the website
+- Copy the `whispercpp`, `whispercpp-cuda` and `whispercpp-models` directories from the Wingman AI installation directory to your repository root.
+- Restart Wingman AI Core and it should autostart whispercpp

--- a/main.py
+++ b/main.py
@@ -63,7 +63,11 @@ if not is_latest:
     )
 
 # uses the Singletons above, so don't move this up!
-core = WingmanCore(config_manager=config_manager, app_root_path=app_root_path)
+core = WingmanCore(
+    config_manager=config_manager,
+    app_root_path=app_root_path,
+    app_is_bundled=app_is_bundled,
+)
 core.set_connection_manager(connection_manager)
 
 keyboard.hook(core.on_key)

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ if not is_latest:
     )
 
 # uses the Singletons above, so don't move this up!
-core = WingmanCore(config_manager=config_manager)
+core = WingmanCore(config_manager=config_manager, app_root_path=app_root_path)
 core.set_connection_manager(connection_manager)
 
 keyboard.hook(core.on_key)

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -68,7 +68,7 @@ class Whispercpp:
             )
 
     def start_server(self):
-        if self.__is_server_running():
+        if self.__is_server_running() or not self.is_windows:
             return True
 
         args = [
@@ -130,10 +130,15 @@ class Whispercpp:
             if requires_restart:
                 self.stop_server()
                 self.start_server()
+            else:
+                self.change_model()
 
-            self.change_model()
+            self.printr.print("whispercpp settings updated.", server_only=True)
 
     def change_model(self, timeout=10):
+        if not self.is_windows:
+            return
+
         if self.current_model != self.settings.model:
             response = requests.post(
                 f"{self.settings.host}:{self.settings.port}/load",

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -115,7 +115,7 @@ class Whispercpp:
     def stop_server(self) -> str:
         if self.runnig_process:
             self.runnig_process.kill()
-            sleep(2)
+            self.runnig_process.wait()
             self.runnig_process = None
             self.printr.print(
                 "whispercpp server stopped.", server_only=True, color=LogType.HIGHLIGHT

--- a/providers/whispercpp.py
+++ b/providers/whispercpp.py
@@ -14,7 +14,12 @@ SERVER_EXE = "server.exe"
 
 
 class Whispercpp:
-    def __init__(self, settings: WhispercppSettings, app_root_path: str):
+    def __init__(
+        self,
+        settings: WhispercppSettings,
+        app_root_path: str,
+        app_is_bundled: bool,
+    ):
         self.settings = settings
         self.current_model = None
         self.runnig_process = None
@@ -23,7 +28,7 @@ class Whispercpp:
         self.is_windows = platform.system() == "Windows"
         if self.is_windows:
             # move one dir up, out of _internal (if bundled)
-            app_dir = path.dirname(app_root_path)
+            app_dir = path.dirname(app_root_path) if app_is_bundled else app_root_path
             self.models_dir = path.join(app_dir, MODELS_DIR)
             self.standard_dir = path.join(app_dir, STANDARD_DIR)
             self.cuda_dir = path.join(app_dir, CUDA_DIR)

--- a/services/module_manager.py
+++ b/services/module_manager.py
@@ -44,6 +44,7 @@ class ModuleManager:
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
+        app_root_path: str,
     ):
         """Dynamically creates a Wingman instance from a module path and class name
 
@@ -73,6 +74,7 @@ class ModuleManager:
             config=config,
             settings=settings,
             audio_player=audio_player,
+            app_root_path=app_root_path,
         )
         return instance
 

--- a/services/module_manager.py
+++ b/services/module_manager.py
@@ -8,6 +8,7 @@ import sys
 from typing import TYPE_CHECKING
 import yaml
 from api.interface import SettingsConfig, SkillBase, SkillConfig, WingmanConfig
+from providers.whispercpp import Whispercpp
 from services.audio_player import AudioPlayer
 from services.file import get_writable_dir
 from services.printr import Printr
@@ -44,7 +45,7 @@ class ModuleManager:
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
-        app_root_path: str,
+        whispercpp: Whispercpp,
     ):
         """Dynamically creates a Wingman instance from a module path and class name
 
@@ -74,7 +75,7 @@ class ModuleManager:
             config=config,
             settings=settings,
             audio_player=audio_player,
-            app_root_path=app_root_path,
+            whispercpp=whispercpp,
         )
         return instance
 

--- a/services/tower.py
+++ b/services/tower.py
@@ -16,13 +16,14 @@ printr = Printr()
 
 
 class Tower:
-    def __init__(self, config: Config, audio_player: AudioPlayer):
+    def __init__(self, config: Config, audio_player: AudioPlayer, app_root_path: str):
         self.audio_player = audio_player
         self.config = config
         self.mouse_wingman_dict: dict[str, Wingman] = {}
         self.wingmen: list[Wingman] = []
         self.disabled_wingmen: list[WingmanConfig] = []
         self.log_source_name = "Tower"
+        self.app_root_path = app_root_path
 
     async def instantiate_wingmen(self, settings: SettingsConfig):
         errors: list[WingmanInitializationError] = []
@@ -74,6 +75,7 @@ class Tower:
                     config=wingman_config,
                     settings=settings,
                     audio_player=self.audio_player,
+                    app_root_path=self.app_root_path,
                 )
             else:
                 wingman = OpenAiWingman(
@@ -81,6 +83,7 @@ class Tower:
                     config=wingman_config,
                     settings=settings,
                     audio_player=self.audio_player,
+                    app_root_path=self.app_root_path,
                 )
         except FileNotFoundError as e:  # pylint: disable=broad-except
             wingman_config.disabled = True

--- a/services/tower.py
+++ b/services/tower.py
@@ -5,6 +5,7 @@ from api.interface import (
     WingmanConfig,
     WingmanInitializationError,
 )
+from providers.whispercpp import Whispercpp
 from services.audio_player import AudioPlayer
 from services.module_manager import ModuleManager
 from services.printr import Printr
@@ -16,14 +17,16 @@ printr = Printr()
 
 
 class Tower:
-    def __init__(self, config: Config, audio_player: AudioPlayer, app_root_path: str):
+    def __init__(
+        self, config: Config, audio_player: AudioPlayer, whispercpp: Whispercpp
+    ):
         self.audio_player = audio_player
         self.config = config
         self.mouse_wingman_dict: dict[str, Wingman] = {}
         self.wingmen: list[Wingman] = []
         self.disabled_wingmen: list[WingmanConfig] = []
         self.log_source_name = "Tower"
-        self.app_root_path = app_root_path
+        self.whispercpp = whispercpp
 
     async def instantiate_wingmen(self, settings: SettingsConfig):
         errors: list[WingmanInitializationError] = []
@@ -75,7 +78,7 @@ class Tower:
                     config=wingman_config,
                     settings=settings,
                     audio_player=self.audio_player,
-                    app_root_path=self.app_root_path,
+                    whispercpp=self.whispercpp,
                 )
             else:
                 wingman = OpenAiWingman(
@@ -83,7 +86,7 @@ class Tower:
                     config=wingman_config,
                     settings=settings,
                     audio_player=self.audio_player,
-                    app_root_path=self.app_root_path,
+                    whispercpp=self.whispercpp,
                 )
         except FileNotFoundError as e:  # pylint: disable=broad-except
             wingman_config.disabled = True

--- a/templates/configs/defaults.yaml
+++ b/templates/configs/defaults.yaml
@@ -106,13 +106,7 @@ azure:
       - en-US
       - de-DE
 whispercpp:
-  host: http://127.0.0.1
-  port: 8080
-  model: ggml-base.bin
-  language: auto
   temperature: 0.0
-  translate_to_english: false
-  use_cuda: false
 xvasynth:
   xvasynth_path: C:\Program Files (x86)\Steam\steamapps\common\xVASynth
   process_device: cpu

--- a/templates/configs/defaults.yaml
+++ b/templates/configs/defaults.yaml
@@ -39,7 +39,7 @@ prompts:
     (END of "skills")
 features:
   tts_provider: wingman_pro
-  stt_provider: wingman_pro
+  stt_provider: whispercpp
   conversation_provider: wingman_pro
   summarize_provider: wingman_pro
   image_generation_provider: wingman_pro
@@ -106,13 +106,13 @@ azure:
       - en-US
       - de-DE
 whispercpp:
-  base_url: http://127.0.0.1:8080
-  autostart: false
-  autostart_settings:
-    whispercpp_exe_path: C:\Whispercpp\server.exe
-    whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin
+  host: http://127.0.0.1
+  port: 8080
+  model: ggml-base.bin
+  language: auto
   temperature: 0.0
-  language: en
+  translate_to_english: false
+  use_cuda: false
 xvasynth:
   xvasynth_path: C:\Program Files (x86)\Steam\steamapps\common\xVASynth
   process_device: cpu

--- a/templates/configs/settings.yaml
+++ b/templates/configs/settings.yaml
@@ -4,26 +4,20 @@ voice_activation:
   enabled: false
   mute_toggle_key: "shift+x"
   energy_threshold: 0.01
-
-  stt_provider: wingman_pro # or azure, whispercpp, openai
-
+  stt_provider: whispercpp # azure, whispercpp, openai
   azure:
     region: westeurope
     languages:
       - en-US
       - de-DE
-
   whispercpp:
-    base_url: http://127.0.0.1:8080
-    autostart: false
-    autostart_settings:
-      whispercpp_exe_path: C:\Whispercpp\server.exe
-      whispercpp_model_path: C:\Whispercpp\models\ggml-base.bin
+    host: http://127.0.0.1
+    port: 8080
+    model: ggml-base.bin
+    language: auto
     temperature: 0.0
-    language: en
-
-# todo: OpenAI base_url and organization
-
+    translate_to_english: false
+    use_cuda: false
 wingman_pro:
   base_url: https://wingman-ai.azurewebsites.net
   region: europe

--- a/templates/configs/settings.yaml
+++ b/templates/configs/settings.yaml
@@ -15,9 +15,10 @@ voice_activation:
     port: 8080
     model: ggml-base.bin
     language: auto
-    temperature: 0.0
     translate_to_english: false
     use_cuda: false
+  whispercpp_config:
+    temperature: 0.0
 wingman_pro:
   base_url: https://wingman-ai.azurewebsites.net
   region: europe

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -23,7 +23,7 @@ from api.interface import (
     WingmanInitializationError,
 )
 from providers.open_ai import OpenAi
-from providers.whispercpp import Whispercpp
+from providers.whispercpp import MODELS_DIR, Whispercpp
 from providers.wingman_pro import WingmanPro
 from wingmen.open_ai_wingman import OpenAiWingman
 from wingmen.wingman import Wingman
@@ -93,14 +93,21 @@ class WingmanCore(WebSocketUser):
         )
         self.router.add_api_route(
             methods=["POST"],
-            path="/send_audio-to-wingman",
+            path="/send-audio-to-wingman",
             endpoint=self.send_audio_to_wingman,
             tags=tags,
         )
         self.router.add_api_route(
             methods=["POST"],
-            path="/reset_conversation_history",
+            path="/reset-conversation-history",
             endpoint=self.reset_conversation_history,
+            tags=tags,
+        )
+        self.router.add_api_route(
+            methods=["GET"],
+            path="/whispercpp-models",
+            response_model=list[str],
+            endpoint=self.get_whispercpp_models,
             tags=tags,
         )
 
@@ -614,3 +621,18 @@ class WingmanCore(WebSocketUser):
                 "Conversation history cleared.",
             )
         return True
+
+    # GET /whispercpp-models
+    def get_whispercpp_models(self):
+        model_files = []
+        try:
+            models_dir = os.path.join(os.path.dirname(self.app_root_path), MODELS_DIR)
+            model_files = [
+                f
+                for f in os.listdir(models_dir)
+                if os.path.isfile(os.path.join(models_dir, f)) and f.endswith(".bin")
+            ]
+        except Exception:
+            # this only works if the app is bundled, so not when running from source
+            pass
+        return model_files

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -158,6 +158,7 @@ class WingmanCore(WebSocketUser):
             settings=self.settings_service.settings.voice_activation.whispercpp,
             app_root_path=app_root_path,
         )
+        self.settings_service.initialize(self.whispercpp)
 
         self.voice_service = VoiceService(
             config_manager=self.config_manager, audio_player=self.audio_player

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -41,8 +41,9 @@ from services.websocket_user import WebSocketUser
 
 
 class WingmanCore(WebSocketUser):
-    def __init__(self, config_manager: ConfigManager):
+    def __init__(self, config_manager: ConfigManager, app_root_path: str):
         self.printr = Printr()
+        self.app_root_path = app_root_path
 
         self.router = APIRouter()
         tags = ["core"]
@@ -178,7 +179,9 @@ class WingmanCore(WebSocketUser):
     async def initialize_tower(self, config_dir_info: ConfigWithDirInfo):
         await self.unload_tower()
         self.tower = Tower(
-            config=config_dir_info.config, audio_player=self.audio_player
+            config=config_dir_info.config,
+            audio_player=self.audio_player,
+            app_root_path=self.app_root_path,
         )
         self.tower_errors = await self.tower.instantiate_wingmen(
             self.config_manager.settings_config
@@ -338,7 +341,9 @@ class WingmanCore(WebSocketUser):
                 return original_text != text, text
 
             whisper_config = self.settings_service.settings.voice_activation.whispercpp
-            whisperccp = Whispercpp(wingman_name="system")
+            whisperccp = Whispercpp(
+                wingman_name="system", app_root_path=self.app_root_path
+            )
             errors = whisperccp.validate_config(whisper_config)
 
             if len(errors) > 0:

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -106,8 +106,20 @@ class WingmanCore(WebSocketUser):
             tags=tags,
         )
         self.router.add_api_route(
+            methods=["POST"],
+            path="/whispercpp/start",
+            endpoint=self.start_whispercpp,
+            tags=tags,
+        )
+        self.router.add_api_route(
+            methods=["POST"],
+            path="/whispercpp/stop",
+            endpoint=self.stop_whispercpp,
+            tags=tags,
+        )
+        self.router.add_api_route(
             methods=["GET"],
-            path="/whispercpp-models",
+            path="/whispercpp/models",
             response_model=list[str],
             endpoint=self.get_whispercpp_models,
             tags=tags,
@@ -620,7 +632,15 @@ class WingmanCore(WebSocketUser):
             )
         return True
 
-    # GET /whispercpp-models
+    # POST /whispercpp/start
+    def start_whispercpp(self):
+        self.whispercpp.start_server()
+
+    # POST /whispercpp/stop
+    def stop_whispercpp(self):
+        self.whispercpp.stop_server()
+
+    # GET /whispercpp/models
     def get_whispercpp_models(self):
         model_files = []
         try:

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -41,7 +41,9 @@ from services.websocket_user import WebSocketUser
 
 
 class WingmanCore(WebSocketUser):
-    def __init__(self, config_manager: ConfigManager, app_root_path: str):
+    def __init__(
+        self, config_manager: ConfigManager, app_root_path: str, app_is_bundled: bool
+    ):
         self.printr = Printr()
         self.app_root_path = app_root_path
 
@@ -157,6 +159,7 @@ class WingmanCore(WebSocketUser):
         self.whispercpp = Whispercpp(
             settings=self.settings_service.settings.voice_activation.whispercpp,
             app_root_path=app_root_path,
+            app_is_bundled=app_is_bundled,
         )
         self.settings_service.initialize(self.whispercpp)
 

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -56,9 +56,14 @@ class OpenAiWingman(Wingman):
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
+        app_root_path: str,
     ):
         super().__init__(
-            name=name, config=config, audio_player=audio_player, settings=settings
+            name=name,
+            config=config,
+            audio_player=audio_player,
+            settings=settings,
+            app_root_path=app_root_path,
         )
 
         self.edge_tts = Edge()
@@ -318,6 +323,7 @@ class OpenAiWingman(Wingman):
     ):
         self.whispercpp = Whispercpp(
             wingman_name=self.name,
+            app_root_path=self.app_root_path,
         )
         validation_errors = self.whispercpp.validate_config(
             config=self.config.whispercpp

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -56,14 +56,14 @@ class OpenAiWingman(Wingman):
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
-        app_root_path: str,
+        whispercpp: Whispercpp,
     ):
         super().__init__(
             name=name,
             config=config,
             audio_player=audio_player,
             settings=settings,
-            app_root_path=app_root_path,
+            whispercpp=whispercpp,
         )
 
         self.edge_tts = Edge()
@@ -122,9 +122,6 @@ class OpenAiWingman(Wingman):
 
         if self.uses_provider("xvasynth"):
             await self.validate_and_set_xvasynth(errors)
-
-        if self.uses_provider("whispercpp"):
-            await self.validate_and_set_whispercpp(errors)
 
         if self.uses_provider("azure"):
             await self.validate_and_set_azure(errors)
@@ -318,18 +315,6 @@ class OpenAiWingman(Wingman):
         validation_errors = self.xvasynth.validate_config(config=self.config.xvasynth)
         errors.extend(validation_errors)
 
-    async def validate_and_set_whispercpp(
-        self, errors: list[WingmanInitializationError]
-    ):
-        self.whispercpp = Whispercpp(
-            wingman_name=self.name,
-            app_root_path=self.app_root_path,
-        )
-        validation_errors = self.whispercpp.validate_config(
-            config=self.config.whispercpp
-        )
-        errors.extend(validation_errors)
-
     async def validate_and_set_wingman_pro(self):
         self.wingman_pro = WingmanPro(
             wingman_name=self.name, settings=self.settings.wingman_pro
@@ -343,6 +328,7 @@ class OpenAiWingman(Wingman):
             self.settings.wingman_pro.base_url != settings.wingman_pro.base_url
             or self.settings.wingman_pro.region != settings.wingman_pro.region
         )
+
         await super().update_settings(settings)
 
         if wingman_pro_changed and self.uses_provider("wingman_pro"):

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -77,7 +77,6 @@ class OpenAiWingman(Wingman):
         self.openai_azure: OpenAiAzure = None
         self.elevenlabs: ElevenLabs = None
         self.xvasynth: XVASynth = None
-        self.whispercpp: Whispercpp = None
         self.wingman_pro: WingmanPro = None
         self.google: GoogleGenAI = None
 

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -37,6 +37,7 @@ class Wingman:
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
+        app_root_path: str,
     ):
         """The constructor of the Wingman class. You can override it in your custom wingman.
 
@@ -62,6 +63,9 @@ class Wingman:
 
         self.execution_start: None | float = None
         """Used for benchmarking executon times. The timer is (re-)started whenever the process function starts."""
+
+        self.app_root_path = app_root_path
+        """The path where the main.py is located. This is the _internal directory inside of the Wingman AI installation directory (in the release version)."""
 
         self.skills: list[Skill] = []
 

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -15,6 +15,7 @@ from api.interface import (
     WingmanInitializationError,
 )
 from api.enums import LogSource, LogType, WingmanInitializationErrorType
+from providers.whispercpp import Whispercpp
 from services.audio_player import AudioPlayer
 from services.module_manager import ModuleManager
 from services.secret_keeper import SecretKeeper
@@ -37,7 +38,7 @@ class Wingman:
         config: WingmanConfig,
         settings: SettingsConfig,
         audio_player: AudioPlayer,
-        app_root_path: str,
+        whispercpp: Whispercpp,
     ):
         """The constructor of the Wingman class. You can override it in your custom wingman.
 
@@ -64,8 +65,8 @@ class Wingman:
         self.execution_start: None | float = None
         """Used for benchmarking executon times. The timer is (re-)started whenever the process function starts."""
 
-        self.app_root_path = app_root_path
-        """The path where the main.py is located. This is the _internal directory inside of the Wingman AI installation directory (in the release version)."""
+        self.whispercpp = whispercpp
+        """A class that handles the communication with the Whispercpp server for transcription."""
 
         self.skills: list[Skill] = []
 


### PR DESCRIPTION
whispercpp is now bundled in our installer package (Tauri/client side) so that we hopefully won't run in any Win Defender issues. This also has the benefit that uninstalling Wingman AI also deletes the whispercpp files.

I created this structure in the Wingman AI install dir:
- whispercpp (base non-CUDA whisper)
- whispercpp-cuda (CUDA whisper)
- whispercpp-models (used by both)

whispercpp is now basically a "fist-class-citizen" and handled similar to AudioPlayer: We create one instance of it very early and then pass it around to whoever needs it. The whispercpp class has been refactored to handle different tasks like starting/stopping the server (on Windows) etc. Autostart obviously only works on Windows. On MacOS, you have to start it manually. 

Dev docs have been updated but you can make use of the autostart functionality even in Windows develop mode (aka running from source). Long story short: Copy the directories mentioned above from the release version install dir into your repository root and Core will autostart it.

The UI has been refactored:
- whispercpp settings are now in Settings. It never made sense that different Wingmen could connect to different whispercpp instances.
- Wingmen can now only override the `temperature` option which is passed to `transcribe()` and doesn't depend on the server being started with certain params
- Changing whispercpp settings will relaunch the whispercpp server process because it's not capable of changing settings at runtime (apart from `change_model` which is done ad-hoc.

![image](https://github.com/ShipBit/wingman-ai/assets/306996/f6d898c1-3fa0-4a23-96b6-0ac982342cb5)
