### PR TITLE
Voice changer xvasynth support

### DIFF
--- a/skills/radio_chatter/default_config.yaml
+++ b/skills/radio_chatter/default_config.yaml
@@ -31,7 +31,7 @@ custom_properties:
     property_type: textarea
   - id: voices
     name: Available voices
-    hint: A list of voices seperated by commas. (voicename or provider.voicename or provider.subprovider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, wingman_pro.openai.nova"
+    hint: A list of voices seperated by commas. (voicename or provider.voicename or provider.subprovider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, wingman_pro.openai.nova, xvasynth.terminator.tn-T850".  Note XVASynth Support requires that you configure and save the wingman at least once with XVASynth as TTS provider so other variables are configured.
     value: ""
     required: false
     property_type: textarea

--- a/skills/voice_changer/default_config.yaml
+++ b/skills/voice_changer/default_config.yaml
@@ -18,7 +18,7 @@ custom_properties:
     property_type: boolean
   - id: voice_changer_voices
     name: Available voices
-    hint: A list of voices seperated by commas. (voicename or provider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural"
+    hint: A list of voices seperated by commas. (voicename or provider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, xvasynth.terminator.tn-T850".  Note XVASynth Support requires that you configure and save the wingman at least once with XVASynth as TTS provider so other variables are configured.
     value: ""
     required: false
     property_type: string

--- a/templates/skills/radio_chatter/default_config.yaml
+++ b/templates/skills/radio_chatter/default_config.yaml
@@ -31,7 +31,7 @@ custom_properties:
     property_type: textarea
   - id: voices
     name: Available voices
-    hint: A list of voices seperated by commas. (voicename or provider.voicename or provider.subprovider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, wingman_pro.openai.nova"
+    hint: A list of voices seperated by commas. (voicename or provider.voicename or provider.subprovider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, wingman_pro.openai.nova, xvasynth.terminator.tn-T850".  Note XVASynth Support requires that you configure and save the wingman at least once with XVASynth as TTS provider so other variables are configured.
     value: ""
     required: false
     property_type: textarea

--- a/templates/skills/voice_changer/default_config.yaml
+++ b/templates/skills/voice_changer/default_config.yaml
@@ -18,7 +18,7 @@ custom_properties:
     property_type: boolean
   - id: voice_changer_voices
     name: Available voices
-    hint: A list of voices seperated by commas. (voicename or provider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural"
+    hint: A list of voices seperated by commas. (voicename or provider.voicename) For example -> "elevenlabs.Alice, elevenlabs.zcAOhNBS3c14rBihAFp1, openai.nova, wingman_pro.azure.en-US-EmmaNeural, xvasynth.terminator.tn-T850".  Note XVASynth Support requires that you configure and save the wingman at least once with XVASynth as TTS provider so other variables are configured.
     value: ""
     required: false
     property_type: string

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -644,11 +644,11 @@ class WingmanCore(WebSocketUser):
     def get_whispercpp_models(self):
         model_files = []
         try:
-            models_dir = os.path.join(os.path.dirname(self.app_root_path), MODELS_DIR)
             model_files = [
                 f
-                for f in os.listdir(models_dir)
-                if os.path.isfile(os.path.join(models_dir, f)) and f.endswith(".bin")
+                for f in os.listdir(self.whispercpp.models_dir)
+                if os.path.isfile(os.path.join(self.whispercpp.models_dir, f))
+                and f.endswith(".bin")
             ]
         except Exception:
             # this only works if the app is bundled, so not when running from source


### PR DESCRIPTION
-As discussed, draft pull request for XVASynth support

-The same changes could be made to radio chatter

-Either XVASynth settings have to be set in default settings config (which I understand might be a target for 1.50 for GUI or wingman has to have been set up with proper XVASynth settings at least once before to save the proper path to XVASynth on the user machine and, if applicable, default voice language).

-Format of a xvasynth voice in the changer would be xvasynth.{voice_folder_name}.{voice_name}.