### PR TITLE
Config migrations

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,15 +47,15 @@ printr.print(
 secret_keeper = SecretKeeper()
 SecretKeeper.set_connection_manager(connection_manager)
 
-version_check = SystemManager()
+system_manager = SystemManager()
 printr.print(
-    f"Wingman AI Core v{version_check.local_version}",
+    f"Wingman AI Core v{system_manager.local_version}",
     server_only=True,
     color=LogType.HIGHLIGHT,
 )
 
-is_latest = version_check.check_version()
-if not is_latest:
+is_latest_version = system_manager.check_version()
+if not is_latest_version:
     printr.print(
         "A new Wingman AI version is available! Download at https://www.wingman-ai.com",
         server_only=True,
@@ -118,8 +118,8 @@ def custom_openapi():
         return app.openapi_schema
     openapi_schema = get_openapi(
         title="Wingman AI Core API",
-        version="1.0.0",
-        description="Communicate with the Wingman AI Core",
+        version="1.5.0",
+        description="Communicate with Wingman AI Core",
         routes=app.routes,
     )
 
@@ -188,7 +188,7 @@ app.include_router(core.config_service.router)
 app.include_router(core.settings_service.router)
 app.include_router(core.voice_service.router)
 
-app.include_router(version_check.router)
+app.include_router(system_manager.router)
 app.include_router(secret_keeper.router)
 
 
@@ -232,6 +232,7 @@ async def ping():
 
 
 async def async_main(host: str, port: int, sidecar: bool):
+    await core.config_service.migrate_configs(system_manager)
     await core.config_service.load_config()
     saved_secrets: list[str] = []
     for error in core.tower_errors:

--- a/main.py
+++ b/main.py
@@ -117,8 +117,8 @@ def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema
     openapi_schema = get_openapi(
-        title="Wingman AI Core API",
-        version="1.5.0",
+        title="Wingman AI Core REST API",
+        version=str(system_manager.local_version),
         description="Communicate with Wingman AI Core",
         routes=app.routes,
     )

--- a/services/config_migration_service.py
+++ b/services/config_migration_service.py
@@ -1,0 +1,193 @@
+from os import path, walk
+import os
+import shutil
+from typing import Callable, Optional
+from pydantic import ValidationError
+from api.enums import LogType
+from api.interface import NestedConfig, SettingsConfig
+from services.config_manager import CONFIGS_DIR, ConfigManager
+from services.file import get_users_dir
+from services.printr import Printr
+
+
+class ConfigMigrationService:
+    def __init__(self, config_manager: ConfigManager):
+        self.config_manager = config_manager
+        self.printr = Printr()
+
+    # MIGRATIONS
+
+    def migrate_140_to_150(self):
+        def migrate_settings(old: dict, new: SettingsConfig) -> dict:
+            old["voice_activation"]["whispercpp_config"] = {
+                "temperature": new.voice_activation.whispercpp_config.temperature
+            }
+            old["voice_activation"]["whispercpp"] = self.config_manager.convert_to_dict(
+                new.voice_activation.whispercpp
+            )
+            self.log("- applied new split whispercpp settings/config structure")
+            return old
+
+        def migrate_defaults(old: dict, new: NestedConfig) -> dict:
+            # add new properties
+            old["sound"]["volume"] = new.sound.volume
+            old["google"] = self.config_manager.convert_to_dict(new.google)
+            self.log("- added new properties: sound.volume, google")
+
+            # remove obsolete properties
+            old["openai"].pop("summarize_model")
+            old["mistral"].pop("summarize_model")
+            old["groq"].pop("summarize_model")
+            old["openrouter"].pop("summarize_model")
+            old["azure"].pop("summarize")
+            old["wingman_pro"].pop("summarize_deployment")
+            self.log("- removed obsolete properties: summarize_model")
+
+            # rest of whispercpp moved to settings.yaml
+            old["whispercpp"] = {"temperature": new.whispercpp.temperature}
+            self.log("- cleaned up whispercpp properties")
+
+            # patching new default values
+            old["features"]["stt_provider"] = new.features.stt_provider.value
+            self.log("- set whispercpp as new default STT provider")
+
+            return old
+
+        def migrate_wingman(old: dict, new: Optional[dict]) -> dict:
+            # remove obsolete properties
+            old.get("openai", {}).pop("summarize_model", None)
+            old.get("mistral", {}).pop("summarize_model", None)
+            old.get("groq", {}).pop("summarize_model", None)
+            old.get("openrouter", {}).pop("summarize_model", None)
+            old.get("azure", {}).pop("summarize", None)
+            old.get("wingman_pro", {}).pop("summarize_deployment", None)
+            self.log(
+                "- removed obsolete properties: summarize_model (if there were any)"
+            )
+
+            old.pop("whispercpp", None)
+            self.log("- removed old whispercpp config (if there was any)")
+
+            return old
+
+        self.migrate(
+            old_version="1_4_0",
+            new_version="1_5_0",
+            migrate_settings=migrate_settings,
+            migrate_defaults=migrate_defaults,
+            migrate_wingman=migrate_wingman,
+        )
+
+    # INTERNAL
+
+    def log(self, message: str, highlight: bool = False):
+        self.printr.print(
+            message,
+            color=LogType.SUBTLE if not highlight else LogType.PURPLE,
+            server_only=True,
+        )
+
+    def err(self, message: str):
+        self.printr.print(
+            message,
+            color=LogType.ERROR,
+            server_only=True,
+        )
+
+    def copy_file(self, old_file: str, new_file: str):
+        new_dir = path.dirname(new_file)
+        if not path.exists(new_dir):
+            os.makedirs(new_dir)
+
+        shutil.copyfile(old_file, new_file)
+
+        self.log(f"Copied file: {path.basename(new_file)}")
+
+    def migrate(
+        self,
+        old_version: str,
+        new_version: str,
+        migrate_settings: Callable[[dict, SettingsConfig], dict],
+        migrate_defaults: Callable[[dict, NestedConfig], dict],
+        migrate_wingman: Callable[[dict, Optional[dict]], dict],
+    ) -> None:
+        users_dir = get_users_dir()
+        old_path = path.join(users_dir, old_version, CONFIGS_DIR)
+        new_path = path.join(users_dir, new_version, CONFIGS_DIR)
+
+        self.log(
+            f"Starting migration from {old_version} to {new_version} in {users_dir}...",
+            True,
+        )
+
+        for root, _dirs, files in walk(old_path):
+            for filename in files:
+                old_file = path.join(root, filename)
+                new_file = old_file.replace(old_path, new_path)
+
+                if filename == ".DS_Store":
+                    continue
+                # secrets
+                if filename == "secrets.yaml":
+                    self.copy_file(old_file, new_file)
+                # settings
+                elif filename == "settings.yaml":
+                    self.log("Migrating settings.yaml...", True)
+                    migrated_settings = migrate_settings(
+                        old=self.config_manager.read_config(old_file),
+                        new=self.config_manager.settings_config,
+                    )
+                    try:
+                        self.config_manager.settings_config = SettingsConfig(
+                            **migrated_settings
+                        )
+                        self.config_manager.save_settings_config()
+                    except ValidationError as e:
+                        self.err(f"Unable to migrate settings.yaml:\n{str(e)}")
+                # defaults
+                elif filename == "defaults.yaml":
+                    self.log("Migrating defaults.yaml...", True)
+                    migrated_defaults = migrate_defaults(
+                        old=self.config_manager.read_config(old_file),
+                        new=self.config_manager.default_config,
+                    )
+                    try:
+                        self.config_manager.default_config = NestedConfig(
+                            **migrated_defaults
+                        )
+                        self.config_manager.save_defaults_config()
+                    except ValidationError as e:
+                        self.err(f"Unable to migrate defaults.yaml:\n{str(e)}")
+                # Wingmen
+                elif filename.endswith(".yaml"):
+                    self.log(f"Migrating Wingman {filename}...", True)
+                    # defaults are already migrated because the Wingman config is in a subdirectory
+                    default_config = self.config_manager.read_default_config()
+                    migrated_wingman = migrate_wingman(
+                        old=self.config_manager.read_config(old_file),
+                        new=(
+                            self.config_manager.read_config(new_file)
+                            if path.exists(new_file)
+                            else None
+                        ),
+                    )
+                    try:
+                        # validate the merged config
+                        _wingman_config = self.config_manager.merge_configs(
+                            default_config, migrated_wingman
+                        )
+                        # diff it
+                        wingman_diff = self.config_manager.deep_diff(
+                            default_config, migrated_wingman
+                        )
+                        # save it
+                        self.config_manager.write_config(new_file, wingman_diff)
+                    except ValidationError as e:
+                        self.err(f"Unable to migrate {filename}:\n{str(e)}")
+                else:
+                    self.copy_file(old_file, new_file)
+        self.printr.print(
+            "Migration completed!",
+            color=LogType.POSITIVE,
+            server_only=True,
+        )

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -1,5 +1,7 @@
+import os
 from typing import Optional
 from fastapi import APIRouter
+from packaging.version import Version, InvalidVersion
 from api.enums import LogType, OpenAiTtsVoice
 from api.interface import (
     BasicWingmanConfig,
@@ -13,9 +15,12 @@ from api.interface import (
     WingmanConfigFileInfo,
 )
 from services.config_manager import ConfigManager
+from services.config_migration_service import ConfigMigrationService
+from services.file import get_users_dir
 from services.module_manager import ModuleManager
 from services.printr import Printr
 from services.pub_sub import PubSub
+from services.system_manager import SystemManager
 from services.tower import Tower
 
 
@@ -487,3 +492,37 @@ class ConfigService:
                             text=f"Inactive Wingman '{wingman_config.name}'s config saved.",
                             server_only=True,
                         )
+
+    async def migrate_configs(self, system_manager: SystemManager):
+        current_version: str = system_manager.get_local_version()
+        current_version_str = str(current_version).replace(".", "_")
+        version_path = get_users_dir()
+
+        def version_key(version_str):
+            try:
+                return Version(version_str.replace("_", "."))
+            except InvalidVersion:
+                return Version("0.0.0")  # Placeholder for invalid versions
+
+        valid_versions = [
+            v for v in os.listdir(version_path) if version_key(v) > Version("0.0.0")
+        ]
+        all_versions = sorted(valid_versions, key=version_key)
+
+        if current_version_str not in all_versions:
+            raise ValueError(
+                f"Current version {current_version} not found in the directory."
+            )
+
+        current_index = all_versions.index(current_version_str)
+
+        if current_index == 0:
+            return  # Current version is the oldest, no migrations needed
+
+        previous_version_str = all_versions[current_index - 1]
+        migration_func_name = f"migrate_{previous_version_str.replace('_', '')}_to_{current_version_str.replace('_', '')}"
+
+        migraton_service = ConfigMigrationService(config_manager=self.config_manager)
+        if hasattr(migraton_service, migration_func_name):
+            migration_func = getattr(migraton_service, migration_func_name)
+            migration_func()

--- a/services/file.py
+++ b/services/file.py
@@ -2,11 +2,14 @@ from os import makedirs, path
 from platformdirs import PlatformDirs
 from services.system_manager import LOCAL_VERSION
 
+APP_NAME = "WingmanAI"
+APP_AUTHOR = "ShipBit"
+
 
 def get_writable_dir(subdir: str = None) -> str:
     dirs = PlatformDirs(
-        appname="WingmanAI",
-        appauthor="ShipBit",
+        appname=APP_NAME,
+        appauthor=APP_AUTHOR,
         version=LOCAL_VERSION.replace(".", "_"),
         ensure_exists=True,
         roaming=True,
@@ -18,3 +21,13 @@ def get_writable_dir(subdir: str = None) -> str:
     if not path.exists(full_path):
         makedirs(full_path)
     return full_path
+
+
+def get_users_dir() -> str:
+    dirs = PlatformDirs(
+        appname=APP_NAME,
+        appauthor=APP_AUTHOR,
+        ensure_exists=True,
+        roaming=True,
+    )
+    return dirs.user_data_dir

--- a/services/printr.py
+++ b/services/printr.py
@@ -34,10 +34,9 @@ class Printr(WebSocketUser):
             ch = logging.StreamHandler()
             ch.setLevel(logging.INFO)
             cls._instance.logger.addHandler(ch)
-            now = datetime.now()
-            dateTimeStr = now.strftime("%Y-%m-%d-%H-%M-%S")
+            date_time_str = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
             fh = logging.FileHandler(
-                path.join(get_writable_dir("logs"), f"wingman-core.{dateTimeStr}.log")
+                path.join(get_writable_dir("logs"), f"wingman-core.{date_time_str}.log")
             )
             fh.setLevel(logging.INFO)
             cls._instance.logger.addHandler(fh)

--- a/services/system_manager.py
+++ b/services/system_manager.py
@@ -4,7 +4,7 @@ import requests
 from packaging import version
 from api.interface import SystemCore, SystemInfo
 
-LOCAL_VERSION = "1.4.1"
+LOCAL_VERSION = "1.5.0"
 VERSION_ENDPOINT = "https://wingman-ai.com/api/version"
 
 

--- a/services/system_manager.py
+++ b/services/system_manager.py
@@ -25,8 +25,6 @@ class SystemManager:
 
     def check_version(self):
         try:
-            app_version = self.local_version
-
             response = requests.get(VERSION_ENDPOINT, timeout=10)
             response.raise_for_status()
 
@@ -35,7 +33,7 @@ class SystemManager:
 
             self.latest_version = remote_version
 
-            return app_version >= remote_version
+            return self.local_version >= remote_version
 
         except requests.RequestException:
             return False


### PR DESCRIPTION
Finally.. config migrations! 

I added a new `ConfigMigratonService` that allows us to dynamically add new migrations later by just adding a function like `def migrate_140_to_150(self)`. This function must provide 3 parts:
- `def migrate_settings(old: dict, new: SettingsConfig) -> dict`
- `def migrate_defaults(old: dict, new: NestedConfig) -> dict:`
- `def migrate_wingman(old: dict, new: Optional[dict]) -> dict:`

and finally it must call the parent `migrate` function like this:

```
self.migrate(
            old_version="1_4_0",
            new_version="1_5_0",
            migrate_settings=migrate_settings,
            migrate_defaults=migrate_defaults,
            migrate_wingman=migrate_wingman,
        )
```

The migration parts themselves are very simple and concentrate on the actual changes. The idea is that you take the `old` config and modify it so that it will finally fit the Pydantic Model structure of the `new` class. Most of the heavy work is done by the parent `migrate` function and you won't have to care about it.

Currently the detection if a migration is required works like this:
- Start in the current config dir, e.g. `1_5_0/configs`
- if there is already a `.migrate` file (which is also a log), migration already ran => break
- else: find the previous release version dir, e.g. `1.4.0/configs` and check if there is a migration function for it. If yes, run it. If no, break

We can later decide if we want to walk the other way around: Start with the oldest dir and find the first one that doesn't have a migration file, then migrate to the next version iteratively - but I postponed that decision to the next migratable version.

From now on, we'll tag PRs that require migration with the appropriate Label here on GitHub and we might ask you to implement the necessary migrations in the migration function for that version.

IMPORTANT: You have to delete your `1.4.1` config dir if you were running the pretest version. I can't write a reliable migration function for it because it had several "phases" of required migration steps and I don't know which one you currently have. If you keep the folder, the logic described above will determine that there is no migration for `141_to_150` and will break, so **DELETE YOUR 1.4.1 config dir if you have one** and your 1.4.0 dir will be migrated as expected.

It's save to play around with this as the old config dir is never touched. Your old configs are save.