### PR TITLE
fixing audio playback reshape error

### DIFF
--- a/services/audio_player.py
+++ b/services/audio_player.py
@@ -340,11 +340,16 @@ class AudioPlayer:
                 if mixed_pos >= len(noise_audio):
                     mixed_pos = 0
                 end_pos = min(len(noise_audio), mixed_pos + remaining)
+
+                num_samples_to_copy = end_pos - mixed_pos
+                if num_samples_to_copy > remaining:
+                    num_samples_to_copy = remaining
+
                 chunk[
-                    length - remaining : length - remaining + (end_pos - mixed_pos)
-                ] = noise_audio[mixed_pos:end_pos]
-                remaining -= end_pos - mixed_pos
-                mixed_pos = end_pos
+                    length - remaining : length - remaining + num_samples_to_copy
+                ] = noise_audio[mixed_pos:(mixed_pos + num_samples_to_copy)]
+                remaining -= num_samples_to_copy
+                mixed_pos = mixed_pos + num_samples_to_copy
             return chunk
 
         def callback(outdata, frames, time, status):


### PR DESCRIPTION
While doing some changes to the radio chatter skill, I found several instances of the audio playback reshape error to happen in the `get_mixed_chunk` function of `audio_player.py`.

After a bit of investigating and I found out, that sometimes the `end_pos - mixed_pos` value was larger than the `remaining` value.
And every time this happened, an error occurred.
Therefore I adjusted the code to not allow that scenario anymore.

I tested with over 600 audio messages afterwards and haven't gotten the error once since this fix.