### PR TITLE
fix fringe bug with ats_telemetry skill

### DIFF
--- a/skills/ats_telemetry/main.py
+++ b/skills/ats_telemetry/main.py
@@ -388,7 +388,7 @@ class ATSTelemetry(Skill):
     # Function to autostart dispatch mode
     async def autostart_dispatcher_mode(self):
         telemetry_started = False
-        while not telemetry_started and self.loaded == True:
+        while not telemetry_started and self.loaded:
             telemetry_started = await self.initialize_telemetry()
             # Init could fail if truck telemetry module already started elsewhere, so make sure we cannot just query truck telemetry data yet to be sure it's not initialized
             if not telemetry_started:

--- a/skills/ats_telemetry/main.py
+++ b/skills/ats_telemetry/main.py
@@ -399,7 +399,7 @@ class ATSTelemetry(Skill):
                     telemetry_started = False
             # Try again in ten seconds; maybe user has not loaded up Truck Simulator yet
             time.sleep(10)
-        if self.loaded == True:
+        if self.loaded:
             await self.initialize_telemetry_cache_loop(10)
 
     # Autostart dispatch mode if option turned on in config

--- a/skills/ats_telemetry/main.py
+++ b/skills/ats_telemetry/main.py
@@ -388,7 +388,7 @@ class ATSTelemetry(Skill):
     # Function to autostart dispatch mode
     async def autostart_dispatcher_mode(self):
         telemetry_started = False
-        while not telemetry_started:
+        while not telemetry_started and self.loaded == True:
             telemetry_started = await self.initialize_telemetry()
             # Init could fail if truck telemetry module already started elsewhere, so make sure we cannot just query truck telemetry data yet to be sure it's not initialized
             if not telemetry_started:
@@ -399,7 +399,8 @@ class ATSTelemetry(Skill):
                     telemetry_started = False
             # Try again in ten seconds; maybe user has not loaded up Truck Simulator yet
             time.sleep(10)
-        await self.initialize_telemetry_cache_loop(10)
+        if self.loaded == True:
+            await self.initialize_telemetry_cache_loop(10)
 
     # Autostart dispatch mode if option turned on in config
     async def prepare(self) -> None:

--- a/templates/skills/ats_telemetry/main.py
+++ b/templates/skills/ats_telemetry/main.py
@@ -388,7 +388,7 @@ class ATSTelemetry(Skill):
     # Function to autostart dispatch mode
     async def autostart_dispatcher_mode(self):
         telemetry_started = False
-        while not telemetry_started and self.loaded == True:
+        while not telemetry_started and self.loaded:
             telemetry_started = await self.initialize_telemetry()
             # Init could fail if truck telemetry module already started elsewhere, so make sure we cannot just query truck telemetry data yet to be sure it's not initialized
             if not telemetry_started:

--- a/templates/skills/ats_telemetry/main.py
+++ b/templates/skills/ats_telemetry/main.py
@@ -399,7 +399,7 @@ class ATSTelemetry(Skill):
                     telemetry_started = False
             # Try again in ten seconds; maybe user has not loaded up Truck Simulator yet
             time.sleep(10)
-        if self.loaded == True:
+        if self.loaded:
             await self.initialize_telemetry_cache_loop(10)
 
     # Autostart dispatch mode if option turned on in config

--- a/templates/skills/ats_telemetry/main.py
+++ b/templates/skills/ats_telemetry/main.py
@@ -388,7 +388,7 @@ class ATSTelemetry(Skill):
     # Function to autostart dispatch mode
     async def autostart_dispatcher_mode(self):
         telemetry_started = False
-        while not telemetry_started:
+        while not telemetry_started and self.loaded == True:
             telemetry_started = await self.initialize_telemetry()
             # Init could fail if truck telemetry module already started elsewhere, so make sure we cannot just query truck telemetry data yet to be sure it's not initialized
             if not telemetry_started:
@@ -399,7 +399,8 @@ class ATSTelemetry(Skill):
                     telemetry_started = False
             # Try again in ten seconds; maybe user has not loaded up Truck Simulator yet
             time.sleep(10)
-        await self.initialize_telemetry_cache_loop(10)
+        if self.loaded == True:
+            await self.initialize_telemetry_cache_loop(10)
 
     # Autostart dispatch mode if option turned on in config
     async def prepare(self) -> None:


### PR DESCRIPTION
-bug where if user started wingman with telemetry that had dispatch autostart on, then never started the game, then switched to another wingman, skill would keep looking to start the telemetry connection in the background

-Fixed by copying Jay's approach in radio chatter to ensure the skill is loaded before initiating the telemetry or starting the loop