### PR TITLE
keyboard write compatibility improvements

### DIFF
--- a/keyboard/keyboard/_winkeyboard.py
+++ b/keyboard/keyboard/_winkeyboard.py
@@ -529,15 +529,17 @@ def listen(callback):
         TranslateMessage(msg)
         DispatchMessage(msg)
 
-def map_name(name):
+def map_name(name, yield_extended=False):
     _setup_name_tables()
-
     entries = from_name.get(name)
     if not entries:
         raise ValueError('Key name {} is not mapped to any known key.'.format(repr(name)))
     for i, entry in entries:
         scan_code, vk, is_extended, modifiers = entry
-        yield scan_code or -vk, modifiers
+        if yield_extended:
+            yield scan_code or -vk, modifiers, is_extended
+        else:
+            yield scan_code or -vk, modifiers
 
 def direct_event(code, event_type):
     _send_event(code, event_type)
@@ -567,8 +569,8 @@ def _send_event(code, event_type):
 
     # alt gr is 541, but it's actually right alt (56, extended)
     if code == 541:
-            code = 56
-            event_type = event_type+1
+        code = 56
+        event_type = event_type+1
     vk = 0
     if code < 0:
         vk = -code

--- a/skills/typing_assistant/main.py
+++ b/skills/typing_assistant/main.py
@@ -68,7 +68,7 @@ class TypingAssistant(Skill):
             content_to_type = parameters.get("content_to_type")
             press_enter = parameters.get("end_by_pressing_enter")
 
-            keyboard.write(content_to_type)
+            keyboard.write(content_to_type, delay=0.01, hold=0.01)
 
             if press_enter is True:
                 keyboard.press("enter")

--- a/templates/skills/typing_assistant/main.py
+++ b/templates/skills/typing_assistant/main.py
@@ -68,7 +68,7 @@ class TypingAssistant(Skill):
             content_to_type = parameters.get("content_to_type")
             press_enter = parameters.get("end_by_pressing_enter")
 
-            keyboard.write(content_to_type)
+            keyboard.write(content_to_type, delay=0.01, hold=0.01)
 
             if press_enter is True:
                 keyboard.press("enter")


### PR DESCRIPTION
Adding compatibility mode to keyboard write function to prefer non-unicode inputs.

Changelog:
- added `hold` and `compatiblity` parameters to `keyboard.write`
- `compatiblity`-mode tries to do a non-unicode input where possible to support inputs in games.
- Default is set to True
- Added `yield_extended` flag to `winkeyboard.py`'s `map_name` function
- small code formatting fixes
- added 10ms hold and delay time in typing assistant skill