### PR TITLE
Fixing wingman pro initializing in skills

### DIFF
--- a/skills/radio_chatter/main.py
+++ b/skills/radio_chatter/main.py
@@ -98,9 +98,7 @@ class RadioChatter(Skill):
                         voice_provider == TtsProvider.WINGMAN_PRO
                         and not self.wingman.wingman_pro
                     ):
-                        await self.wingman.validate_and_set_wingman_pro(errors)
-                        if len(errors) > 0:
-                            initiate_provider_error = True
+                        await self.wingman.validate_and_set_wingman_pro()
 
             if not initiate_provider_error:
                 self.voices = voices

--- a/skills/voice_changer/main.py
+++ b/skills/voice_changer/main.py
@@ -100,9 +100,7 @@ class VoiceChanger(Skill):
                         voice_provider == TtsProvider.WINGMAN_PRO
                         and not self.wingman.wingman_pro
                     ):
-                        await self.wingman.validate_and_set_wingman_pro(errors)
-                        if len(errors) > 0:
-                            initiate_provider_error = True
+                        await self.wingman.validate_and_set_wingman_pro()
 
             if not initiate_provider_error:
                 self.voices = voices

--- a/templates/skills/radio_chatter/main.py
+++ b/templates/skills/radio_chatter/main.py
@@ -98,9 +98,7 @@ class RadioChatter(Skill):
                         voice_provider == TtsProvider.WINGMAN_PRO
                         and not self.wingman.wingman_pro
                     ):
-                        await self.wingman.validate_and_set_wingman_pro(errors)
-                        if len(errors) > 0:
-                            initiate_provider_error = True
+                        await self.wingman.validate_and_set_wingman_pro()
 
             if not initiate_provider_error:
                 self.voices = voices

--- a/templates/skills/voice_changer/main.py
+++ b/templates/skills/voice_changer/main.py
@@ -100,9 +100,7 @@ class VoiceChanger(Skill):
                         voice_provider == TtsProvider.WINGMAN_PRO
                         and not self.wingman.wingman_pro
                     ):
-                        await self.wingman.validate_and_set_wingman_pro(errors)
-                        if len(errors) > 0:
-                            initiate_provider_error = True
+                        await self.wingman.validate_and_set_wingman_pro()
 
             if not initiate_provider_error:
                 self.voices = voices


### PR DESCRIPTION
Changelog:
- removing `error` parameter for `validate_and_set_wingman_pro` in radio chatter and voice changer skill