### PR TITLE
Fix playback condition in auto_stop_playback method

### DIFF
--- a/skills/thinking_sound/main.py
+++ b/skills/thinking_sound/main.py
@@ -71,7 +71,7 @@ class ThinkingSound(Skill):
 
     async def auto_stop_playback(self):
         # Wait for main playback to start
-        while not self.wingman.audio_player.is_playing and self.active:
+        while not ( self.wingman.audio_player.stream or self.wingman.audio_player.raw_stream ) and self.active:
             await asyncio.sleep(0.1)
 
         if self.wingman.settings.debug_mode:

--- a/templates/skills/thinking_sound/main.py
+++ b/templates/skills/thinking_sound/main.py
@@ -71,7 +71,7 @@ class ThinkingSound(Skill):
 
     async def auto_stop_playback(self):
         # Wait for main playback to start
-        while not self.wingman.audio_player.is_playing and self.active:
+        while not ( self.wingman.audio_player.stream or self.wingman.audio_player.raw_stream ) and self.active:
             await asyncio.sleep(0.1)
 
         if self.wingman.settings.debug_mode:


### PR DESCRIPTION
The auto_stop_playback method now correctly checks for both stream and raw_stream states instead of just the is_playing state. This ensures that the playback is properly detected and handled even in different streaming scenarios.