### PR TITLE
Fix audio playback in audio library not stopping completely

### DIFF
--- a/services/audio_library.py
+++ b/services/audio_library.py
@@ -103,6 +103,7 @@ class AudioLibrary:
                 volume[0] -= step_size
                 await asyncio.sleep(step_duration)
             await asyncio.sleep(0.05)  # 50ms grace period
+            audio_player.on_playback_finished = None
             await audio_player.stop_playback()
 
         for file in self.__get_audio_file_config(audio_file).files:
@@ -119,8 +120,10 @@ class AudioLibrary:
                         fade_out_resolution,
                     )
                 else:
+                    audio_player.on_playback_finished = None
                     await audio_player.stop_playback()
 
+                self.notify_playback_finished(self.__get_playback_key(file))
                 self.current_playbacks.pop(self.__get_playback_key(file), None)
 
     def get_playback_status(


### PR DESCRIPTION
Clear the playback finished callback before stopping playback. This ensures that the callback is not called after the playback has already been stopped, preventing potential issues.

Issues was, that after time x, when the playback would have finished, the finished callback was called again if the playback was manually stopped before. This let to a false status in the audio library if the same audio file was started again before the first playback would have finished.