### PR TITLE
Sync names from Star Citizen to fasterwhisper hotwords list

### DIFF
--- a/skills/uexcorp/default_config.yaml
+++ b/skills/uexcorp/default_config.yaml
@@ -110,3 +110,12 @@ custom_properties:
     required: true
     property_type: boolean
   ### Profit Calculation End ###
+
+  ### FasterWhisper Start ###
+  - id: add_fasterwhisper_hotwords
+    name: Update Hotwords (FasterWhisper only)
+    hint: If enabled, this skill will update the FasterWhisper hotwords using common names in the Star Citizen universe. Voice detection might be improved, but bias towards Star Citizen content is possible.
+    value: false
+    required: true
+    property_type: boolean
+  ### FasterWhisper End ###

--- a/skills/uexcorp/uexcorp/handler/config_handler.py
+++ b/skills/uexcorp/uexcorp/handler/config_handler.py
@@ -34,6 +34,7 @@ class ConfigHandler:
         self.__behavior_commodity_route_default_count: int = 1
         self.__behavior_commodity_route_use_estimated_availability: bool = True
         self.__behavior_commodity_route_advanced_info: bool = False
+        self.__behavior_use_fasterwhisper_hotwords: bool = False
 
     async def validate(self, errors: list[WingmanInitializationError], retrieve_custom_property_value: callable) -> list[WingmanInitializationError]:
         try:
@@ -57,32 +58,32 @@ class ConfigHandler:
             if retrieve_custom_property_value("tool_commodity_information", errors):
                 self.__behavior_enabled_tools.append(CommodityInformation.TOOL_NAME)
                 if CommodityInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_commodity_route", errors):
                 self.__behavior_enabled_tools.append(CommodityRoute.TOOL_NAME)
                 if CommodityRoute.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_item_information", errors):
                 self.__behavior_enabled_tools.append(ItemInformation.TOOL_NAME)
                 if ItemInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_location_information", errors):
                 self.__behavior_enabled_tools.append(LocationInformation.TOOL_NAME)
                 if LocationInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_vehicle_information", errors):
                 self.__behavior_enabled_tools.append(VehicleInformation.TOOL_NAME)
                 if VehicleInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_profit_calculation", errors):
                 self.__behavior_enabled_tools.append(ProfitCalculation.TOOL_NAME)
                 if ProfitCalculation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if needs_authentication:
                 api_key = await self.__helper.get_handler_secret().retrieve(
@@ -92,6 +93,10 @@ class ConfigHandler:
                 )
                 if api_key:
                     self.set_api_key(api_key)
+
+            self.set_behavior_update_fasterwhisper_hotwords(
+                retrieve_custom_property_value("add_fasterwhisper_hotwords", errors)
+            )
 
             self.set_behavior_commodity_route_default_count(
                 retrieve_custom_property_value("commodity_route_default_count", errors)
@@ -298,6 +303,12 @@ class ConfigHandler:
 
     def set_behavior_commodity_route_advanced_info(self, advanced_info: bool):
         self.__behavior_commodity_route_advanced_info = advanced_info
+
+    def get_behavior_use_fasterwhisper_hotwords(self) -> bool:
+        return self.__behavior_use_fasterwhisper_hotwords
+
+    def set_behavior_update_fasterwhisper_hotwords(self, update: bool):
+        self.__behavior_use_fasterwhisper_hotwords = update
 
     def set_wingman(self, wingman: "OpenAiWingman"):
         self.__wingman = wingman

--- a/skills/uexcorp/uexcorp/helper.py
+++ b/skills/uexcorp/uexcorp/helper.py
@@ -99,6 +99,70 @@ class Helper:
         self.get_handler_config().sync_blacklists()
         self.__version_uex = self.get_handler_import().get_version_uex()
         self.set_ready(True)
+        self.sync_fasterwhisper_hotwords()
+
+    def sync_fasterwhisper_hotwords(self):
+        if not self.get_handler_config().get_behavior_use_fasterwhisper_hotwords():
+            return
+
+        self.__handler_debug.write("Syncing UEX data with FasterWhisper hotwords ...")
+        try:
+            from skills.uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
+            from skills.uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
+            from skills.uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
+            from skills.uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
+            from skills.uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
+            from skills.uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
+            from skills.uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
+            from skills.uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
+            from skills.uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
+            from skills.uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
+            from skills.uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
+            from skills.uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+        except ModuleNotFoundError:
+            from uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
+            from uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
+            from uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
+            from uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
+            from uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
+            from uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
+            from uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
+            from uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
+            from uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
+            from uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
+            from uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
+            from uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+
+        data_access_instances = [
+            CityDataAccess(),
+            CommodityDataAccess(),
+            CompanyDataAccess(),
+            ItemDataAccess(),
+            MoonDataAccess(),
+            OutpostDataAccess(),
+            PlanetDataAccess(),
+            PoiDataAccess(),
+            SpaceStationDataAccess(),
+            StarSystemDataAccess(),
+            TerminalDataAccess(),
+            VehicleDataAccess(),
+        ]
+
+        hotwordlist = self.get_wingmen().config.fasterwhisper.hotwords or ""
+        hotwords = hotwordlist.split(",")
+        if "UEX" not in hotwords:
+            hotwords.append("UEX")
+        count = len(hotwords)
+        for data_access in data_access_instances:
+            data = data_access.load()
+            for item in data:
+                chunks = str(item).split(" ")
+                for chunk in chunks:
+                    if chunk not in hotwords:
+                        hotwords.append(chunk)
+        count = len(hotwords) - count
+        self.get_wingmen().config.fasterwhisper.hotwords = ",".join(hotwords)
+        self.__handler_debug.write(f"Synced {count} new hotwords with FasterWhisper.")
 
     def wait(self, seconds: int):
         time.sleep(seconds)

--- a/templates/skills/uexcorp/default_config.yaml
+++ b/templates/skills/uexcorp/default_config.yaml
@@ -110,3 +110,12 @@ custom_properties:
     required: true
     property_type: boolean
   ### Profit Calculation End ###
+
+  ### FasterWhisper Start ###
+  - id: add_fasterwhisper_hotwords
+    name: Update Hotwords (FasterWhisper only)
+    hint: If enabled, this skill will update the FasterWhisper hotwords using common names in the Star Citizen universe. Voice detection might be improved, but bias towards Star Citizen content is possible.
+    value: false
+    required: true
+    property_type: boolean
+  ### FasterWhisper End ###

--- a/templates/skills/uexcorp/uexcorp/handler/config_handler.py
+++ b/templates/skills/uexcorp/uexcorp/handler/config_handler.py
@@ -34,6 +34,7 @@ class ConfigHandler:
         self.__behavior_commodity_route_default_count: int = 1
         self.__behavior_commodity_route_use_estimated_availability: bool = True
         self.__behavior_commodity_route_advanced_info: bool = False
+        self.__behavior_use_fasterwhisper_hotwords: bool = False
 
     async def validate(self, errors: list[WingmanInitializationError], retrieve_custom_property_value: callable) -> list[WingmanInitializationError]:
         try:
@@ -57,32 +58,32 @@ class ConfigHandler:
             if retrieve_custom_property_value("tool_commodity_information", errors):
                 self.__behavior_enabled_tools.append(CommodityInformation.TOOL_NAME)
                 if CommodityInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_commodity_route", errors):
                 self.__behavior_enabled_tools.append(CommodityRoute.TOOL_NAME)
                 if CommodityRoute.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_item_information", errors):
                 self.__behavior_enabled_tools.append(ItemInformation.TOOL_NAME)
                 if ItemInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_location_information", errors):
                 self.__behavior_enabled_tools.append(LocationInformation.TOOL_NAME)
                 if LocationInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_vehicle_information", errors):
                 self.__behavior_enabled_tools.append(VehicleInformation.TOOL_NAME)
                 if VehicleInformation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if retrieve_custom_property_value("tool_profit_calculation", errors):
                 self.__behavior_enabled_tools.append(ProfitCalculation.TOOL_NAME)
                 if ProfitCalculation.REQUIRES_AUTHENTICATION:
-                    needs_authentication = False
+                    needs_authentication = True
 
             if needs_authentication:
                 api_key = await self.__helper.get_handler_secret().retrieve(
@@ -92,6 +93,10 @@ class ConfigHandler:
                 )
                 if api_key:
                     self.set_api_key(api_key)
+
+            self.set_behavior_update_fasterwhisper_hotwords(
+                retrieve_custom_property_value("add_fasterwhisper_hotwords", errors)
+            )
 
             self.set_behavior_commodity_route_default_count(
                 retrieve_custom_property_value("commodity_route_default_count", errors)
@@ -298,6 +303,12 @@ class ConfigHandler:
 
     def set_behavior_commodity_route_advanced_info(self, advanced_info: bool):
         self.__behavior_commodity_route_advanced_info = advanced_info
+
+    def get_behavior_use_fasterwhisper_hotwords(self) -> bool:
+        return self.__behavior_use_fasterwhisper_hotwords
+
+    def set_behavior_update_fasterwhisper_hotwords(self, update: bool):
+        self.__behavior_use_fasterwhisper_hotwords = update
 
     def set_wingman(self, wingman: "OpenAiWingman"):
         self.__wingman = wingman

--- a/templates/skills/uexcorp/uexcorp/helper.py
+++ b/templates/skills/uexcorp/uexcorp/helper.py
@@ -99,6 +99,70 @@ class Helper:
         self.get_handler_config().sync_blacklists()
         self.__version_uex = self.get_handler_import().get_version_uex()
         self.set_ready(True)
+        self.sync_fasterwhisper_hotwords()
+
+    def sync_fasterwhisper_hotwords(self):
+        if not self.get_handler_config().get_behavior_use_fasterwhisper_hotwords():
+            return
+
+        self.__handler_debug.write("Syncing UEX data with FasterWhisper hotwords ...")
+        try:
+            from skills.uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
+            from skills.uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
+            from skills.uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
+            from skills.uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
+            from skills.uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
+            from skills.uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
+            from skills.uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
+            from skills.uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
+            from skills.uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
+            from skills.uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
+            from skills.uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
+            from skills.uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+        except ModuleNotFoundError:
+            from uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
+            from uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
+            from uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
+            from uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
+            from uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
+            from uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
+            from uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
+            from uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
+            from uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
+            from uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
+            from uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
+            from uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+
+        data_access_instances = [
+            CityDataAccess(),
+            CommodityDataAccess(),
+            CompanyDataAccess(),
+            ItemDataAccess(),
+            MoonDataAccess(),
+            OutpostDataAccess(),
+            PlanetDataAccess(),
+            PoiDataAccess(),
+            SpaceStationDataAccess(),
+            StarSystemDataAccess(),
+            TerminalDataAccess(),
+            VehicleDataAccess(),
+        ]
+
+        hotwordlist = self.get_wingmen().config.fasterwhisper.hotwords or ""
+        hotwords = hotwordlist.split(",")
+        if "UEX" not in hotwords:
+            hotwords.append("UEX")
+        count = len(hotwords)
+        for data_access in data_access_instances:
+            data = data_access.load()
+            for item in data:
+                chunks = str(item).split(" ")
+                for chunk in chunks:
+                    if chunk not in hotwords:
+                        hotwords.append(chunk)
+        count = len(hotwords) - count
+        self.get_wingmen().config.fasterwhisper.hotwords = ",".join(hotwords)
+        self.__handler_debug.write(f"Synced {count} new hotwords with FasterWhisper.")
 
     def wait(self, seconds: int):
         time.sleep(seconds)


### PR DESCRIPTION
Changelog:
- add uex skill config option `Update Hotwords`
- add sync function to get all names withing star citizen (locations, items, commodities and vehicles) and add them to the fasterwhisper hotlist.
- small code fix for authentication needed flag in config manager