### PR TITLE
Add instance management and validation for UEXCorp skill initialization

### DIFF
--- a/skills/uexcorp/uexcorp/helper.py
+++ b/skills/uexcorp/uexcorp/helper.py
@@ -36,6 +36,10 @@ class Helper:
             cls._instance = cls()
         return cls._instance
 
+    @classmethod
+    def destroy_instance(cls):
+        cls._instance = None
+
     def __init__(self):
         self.__is_loaded = None
         self.__data_path: str = get_writable_dir(path.join("skills", "uexcorp", "data"))

--- a/templates/skills/uexcorp/uexcorp/helper.py
+++ b/templates/skills/uexcorp/uexcorp/helper.py
@@ -36,6 +36,10 @@ class Helper:
             cls._instance = cls()
         return cls._instance
 
+    @classmethod
+    def destroy_instance(cls):
+        cls._instance = None
+
     def __init__(self):
         self.__is_loaded = None
         self.__data_path: str = get_writable_dir(path.join("skills", "uexcorp", "data"))

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -100,6 +100,7 @@ class OpenAiWingman(Wingman):
         try:
             if self.uses_provider("whispercpp"):
                 self.whispercpp.validate(self.name, errors)
+
             if self.uses_provider("fasterwhisper"):
                 self.fasterwhisper.validate(errors)
 

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -231,7 +231,7 @@ class Wingman:
 
                     errors.extend(validation_errors)
 
-                    if len(errors) == 0:
+                    if len(validation_errors) == 0:
                         self.skills.append(skill)
                         await self.prepare_skill(skill)
                         await skill.prepare()


### PR DESCRIPTION
This pull request introduces several changes to improve the initialization and validation processes for the UEXCorp skill. Key changes include handling multiple instances of the skill, adding error handling for invalid sessions, and ensuring proper cleanup of the helper instance.

Initialization and validation improvements:

* `skills/uexcorp/main.py` and `templates/skills/uexcorp/main.py`: Added a check to ensure only one instance of the UEXCorp skill is initialized at a time, setting `self.__invalid_session` to `True` if another instance is detected, and handling this invalid session in the `prepare`, `unload`, and `validate` methods. [[1]](diffhunk://#diff-fc994fbecdea22bf353398b8be432da7d4a44789140dadc02123d9a0e20092abR31-R56) [[2]](diffhunk://#diff-fc994fbecdea22bf353398b8be432da7d4a44789140dadc02123d9a0e20092abR75-R85)
* `skills/uexcorp/uexcorp/helper.py` and `templates/skills/uexcorp/uexcorp/helper.py`: Added a `destroy_instance` class method to reset the helper instance to `None` for proper cleanup.

Code cleanup and minor fixes:

* [`wingmen/open_ai_wingman.py`](diffhunk://#diff-ed52266b26698a5faa82734d566aa80aa927a7ceed409510c315c6d34d4d85eaR103): Added a missing newline in the `validate` method for better readability.
* [`wingmen/wingman.py`](diffhunk://#diff-31102248ce0927a82b5f3dd3887603f35adfc2afb08887ec639c5cfb94a5666eL234-R234): Corrected the condition to check the length of `validation_errors` instead of `errors` when appending skills.