### PR TITLE
Fix encoding issues in StreamToLogger and set log file encoding to UTF-8

### DIFF
--- a/services/printr.py
+++ b/services/printr.py
@@ -22,7 +22,10 @@ class StreamToLogger:
         try:
             for line in buf.rstrip().splitlines():
                 self.logger.log(self.log_level, line.rstrip())
-                self.stream.write(line + "\n")
+                if isinstance(line, str):
+                    self.stream.write(line.encode('utf-8', errors='replace').decode('utf-8') + "\n")
+                else:
+                    self.stream.write(line + "\n")
         except Exception as e:
             original_stderr = getattr(sys, '__stderr__', sys.stderr)
             original_stderr.write(f"Error in StreamToLogger: {str(e)} - Buffer: {buf}\n")
@@ -64,7 +67,8 @@ class Printr(WebSocketUser):
             timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             # log file with timestamp
             fh = RotatingFileHandler(
-                path.join(get_writable_dir("logs"), f"wingman-core.{timestamp}.log")
+                path.join(get_writable_dir("logs"), f"wingman-core.{timestamp}.log"),
+                encoding='utf-8'
             )
             fh.setLevel(logging.DEBUG)
             file_formatter = Formatter(


### PR DESCRIPTION
This pull request includes updates to the `services/printr.py` file to improve encoding handling and logging functionality. The most important changes include ensuring string encoding in the `write` method and specifying the encoding for the log file handler.

Enhancements to encoding and logging:

* [`services/printr.py`](diffhunk://#diff-a58100882acb6c2c3f2e985f45bf5956c5cd56c2bf6d70bf1f420cb96461cf55R25-R27): In the `write` method, added a check to ensure that strings are encoded in UTF-8 before being written to the stream.
* [`services/printr.py`](diffhunk://#diff-a58100882acb6c2c3f2e985f45bf5956c5cd56c2bf6d70bf1f420cb96461cf55L67-R71): In the `__new__` method, specified the encoding as 'utf-8' for the log file handler to ensure proper handling of character encoding in log files.