### PR TITLE
Migrate models for Perplexity

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -81,15 +81,14 @@ class MistralModel(Enum):
 
 
 class PerplexityModel(Enum):
-    """https://docs.perplexity.ai/guides/model-cards"""
+    """https://docs.perplexity.ai/models/model-cards"""
 
-    SONAR_SMALL = "llama-3.1-sonar-small-128k-online"
-    SONAR_MEDIUM = "llama-3.1-sonar-large-128k-online"
-    SONAR_LARGE = "llama-3.1-sonar-huge-128k-online"
-    CHAT_SMALL = "llama-3.1-sonar-small-128k-chat"
-    CHAT_LARGE = "llama-3.1-sonar-large-128k-chat"
-    LLAMA3_8B = "llama-3.1-8b-instruct"
-    LLAMA3_70B = "llama-3.1-70b-instruct"
+    SONAR_DEEP_SEARCH = "sonar-deep-research"
+    SONAR_REASON_PRO = "sonar-reasoning-pro"
+    SONAR_REASON = "sonar-reasoning"
+    SONAR_PRO = "sonar-pro"
+    SONAR = "sonar"
+    R1_1776 = "r1-1776"
 
 
 class GoogleAiModel(Enum):

--- a/services/config_migration_service.py
+++ b/services/config_migration_service.py
@@ -447,12 +447,18 @@ class ConfigMigrationService:
             return old
 
         def migrate_defaults(old: dict, new: dict) -> dict:
+            # openai tts
             old["openai"]["tts_model"] = "tts-1"
             old["openai"]["tts_speed"] = 1.0
             self.log("- added new properties: openai.tts_model, openai.tts_speed")
+
+            # perplexity model
+            old["perplexity"]["conversation_model"] = "sonar"
+            self.log("- migrated perplexity model to new default (sonar), previous models don't exist anymore")
             return old
 
         def migrate_wingman(old: dict, new: Optional[dict]) -> dict:
+            # skill overrides
             if old.get("skills", None):
                 for skill in old["skills"]:
                     skill.pop("description", None)
@@ -462,6 +468,15 @@ class ConfigMigrationService:
                     self.log(
                         "- removed Skill property overrides: description, examples, category, hint"
                     )
+
+            # perplexity model
+            if old.get("perplexity", {}).get("conversation_model", None):
+                # models got replaced
+                old["perplexity"]["conversation_model"] = "sonar"
+                self.log(
+                    "- migrated perplexity model to new default (sonar), previous models don't exist anymore"
+                )
+
             return old
 
         self.migrate(

--- a/templates/configs/defaults.yaml
+++ b/templates/configs/defaults.yaml
@@ -58,7 +58,7 @@ mistral:
   conversation_model: mistral-large-latest
   endpoint: https://api.mistral.ai/v1
 perplexity:
-  conversation_model: llama-3.1-sonar-large-128k-online
+  conversation_model: sonar
   endpoint: https://api.perplexity.ai
 groq:
   conversation_model: llama3-70b-8192


### PR DESCRIPTION
This pull request updates the `PerplexityModel` enum to reflect new model names, adjusts related configuration defaults, and ensures backward compatibility by migrating old settings to align with the updated models. Below are the most important changes grouped by theme:

### Enum Updates:
* [`api/enums.py`](diffhunk://#diff-d4c95450ecbdde3edf5e9df76c7c09b35f3b0a98a947355e90099259cc3049feL84-R91): Replaced outdated model names in the `PerplexityModel` enum with new ones such as `SONAR_DEEP_SEARCH`, `SONAR_REASON_PRO`, and `R1_1776`. Updated the docstring link to reflect the new model documentation.

### Configuration Defaults:
* [`templates/configs/defaults.yaml`](diffhunk://#diff-f52eca806b5f78e12e3bb6d2f058e6fb01ef1cff8f0864d75a2e254af25decc7L61-R61): Updated the default `conversation_model` for `perplexity` from `llama-3.1-sonar-large-128k-online` to `sonar`.

### Migration Logic:
* `services/config_migration_service.py`: 
  - Added migration logic in `migrate_settings` to set the `conversation_model` for `perplexity` to `sonar` and logged the change.
  - Enhanced `migrate_wingman` to replace old `conversation_model` values for `perplexity` with `sonar` and log the update.