### PR TITLE
Refactor FasterWhisper hotwords

### DIFF
--- a/api/interface.py
+++ b/api/interface.py
@@ -139,7 +139,8 @@ class WhispercppSttConfig(BaseModel):
 class FasterWhisperSttConfig(BaseModel):
     beam_size: int
     language: Optional[str] = None
-    hotwords: Optional[str] = None
+    hotwords: Optional[list[str]] = None
+    additional_hotwords: Optional[list[str]] = None
     best_of: int
     temperature: float
     no_speech_threshold: float

--- a/api/interface.py
+++ b/api/interface.py
@@ -139,8 +139,8 @@ class WhispercppSttConfig(BaseModel):
 class FasterWhisperSttConfig(BaseModel):
     beam_size: int
     language: Optional[str] = None
-    hotwords: Optional[list[str]] = None
-    additional_hotwords: Optional[list[str]] = None
+    hotwords: list[str]
+    additional_hotwords: list[str]
     best_of: int
     temperature: float
     no_speech_threshold: float

--- a/providers/faster_whisper.py
+++ b/providers/faster_whisper.py
@@ -60,13 +60,8 @@ class FasterWhisper:
         self,
         config: FasterWhisperSttConfig,
         filename: str,
-        initial_hotwords: Optional[str],
+        hotwords: Optional[list[str]],
     ):
-        hotwords = []
-        if initial_hotwords:
-            hotwords.append(initial_hotwords)
-        if config.hotwords:
-            hotwords.append(config.hotwords)
         try:
             segments, info = self.model.transcribe(
                 filename,
@@ -74,7 +69,9 @@ class FasterWhisper:
                 beam_size=config.beam_size,
                 best_of=config.best_of,
                 temperature=config.temperature,
-                hotwords=", ".join(hotwords) if len(hotwords) > 0 else None,
+                hotwords=(
+                    ", ".join(hotwords) if hotwords and len(hotwords) > 0 else None
+                ),
                 no_speech_threshold=config.no_speech_threshold,
                 language=config.language if config.language else None,
                 multilingual=False if config.language else config.multilingual,

--- a/services/config_migration_service.py
+++ b/services/config_migration_service.py
@@ -451,6 +451,25 @@ class ConfigMigrationService:
                 old["wingman_pro"]["base_url"] = "https://wingman-api-usa.azurewebsites.net"
 
             self.log(f"- set new base url based on region {old_region}")
+            
+            # hotwords was a comma-separated string, now it's a list
+            if isinstance(
+                old["voice_activation"]["fasterwhisper_config"].get("hotwords"), str
+            ):
+                old["voice_activation"]["fasterwhisper_config"]["hotwords"] = list(
+                    set(
+                        [
+                            word.strip()
+                            for word in old["voice_activation"]["fasterwhisper_config"][
+                                "hotwords"
+                            ].split(",")
+                            if word.strip()
+                        ]
+                    )
+                )
+            else:
+                old["voice_activation"]["fasterwhisper_config"]["hotwords"] = []
+            self.log("- migrated Voice Activation hotwords from string to list format")
             return old
 
         def migrate_defaults(old: dict, new: dict) -> dict:
@@ -472,6 +491,24 @@ class ConfigMigrationService:
                 "- migrated perplexity model to new default (sonar), previous models don't exist anymore"
             )
 
+            # hotwords was a comma-separated string, now it's a list
+            if isinstance(old["fasterwhisper"].get("hotwords"), str):
+                old["fasterwhisper"]["additional_hotwords"] = list(
+                    set(
+                        [
+                            word.strip()
+                            for word in old["fasterwhisper"]["hotwords"].split(",")
+                            if word.strip()
+                        ]
+                    )
+                )
+            else:
+                old["fasterwhisper"]["additional_hotwords"] = []
+
+            old["fasterwhisper"]["hotwords"] = []
+            self.log(
+                "- migrated old hotwords from string to list to new additional_hotwords"
+            )
             return old
 
         def migrate_wingman(old: dict, new: Optional[dict]) -> dict:

--- a/skills/uexcorp/uexcorp/helper.py
+++ b/skills/uexcorp/uexcorp/helper.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from os import path
 from services.file import get_writable_dir
 from services.secret_keeper import SecretKeeper
+
 try:
     from skills.uexcorp.uexcorp.handler.config_handler import ConfigHandler
     from skills.uexcorp.uexcorp.database.database import Database
@@ -27,9 +28,11 @@ if TYPE_CHECKING:
         from uexcorp.uexcorp.handler.tool_handler import ToolHandler
     from wingmen.open_ai_wingman import OpenAiWingman
 
+
 class Helper:
 
     _instance = None
+
     @classmethod
     def get_instance(cls) -> "Helper":
         if cls._instance is None:
@@ -50,7 +53,9 @@ class Helper:
         self.__debug: bool = True
         self.__default_thread = threading.get_ident()
         self.__handler_debug: DebugHandler = DebugHandler(self)
-        self.__handler_debug.write("===================================== INIT =====================================")
+        self.__handler_debug.write(
+            "===================================== INIT ====================================="
+        )
         self.__handler_error: ErrorHandler = ErrorHandler(self)
         self.__handler_config: ConfigHandler = ConfigHandler(self)
         self.__handler_tool = None
@@ -62,7 +67,9 @@ class Helper:
         self.__threaded_execution: callable | None = None
         self.__is_ready = False
         self.__secret_keeper = SecretKeeper()
-        self.__secret_keeper.secret_events.subscribe("secrets_saved", self.on_secret_changed)
+        self.__secret_keeper.secret_events.subscribe(
+            "secrets_saved", self.on_secret_changed
+        )
         self.__request_while_not_ready = False
         self.__wingman = None
 
@@ -74,7 +81,9 @@ class Helper:
 
         self.__wingman = wingman
         self.__threaded_execution = threaded_execution
-        self.__database: Database = Database(self.__data_path, self.get_version_skill(), self)
+        self.__database: Database = Database(
+            self.__data_path, self.get_version_skill(), self
+        )
         self.__handler_import: ImportHandler = ImportHandler(self)
         self.__handler_tool: ToolHandler = ToolHandler(self)
         self.__llm: Llm = Llm(self)
@@ -86,14 +95,24 @@ class Helper:
         old_version_skill = self.__version_skill
         old_version_uex = self.get_version_uex()
 
-        if old_version_skill != self.get_version_skill() or old_version_uex != self.get_version_uex(force_check):
+        if (
+            old_version_skill != self.get_version_skill()
+            or old_version_uex != self.get_version_uex(force_check)
+        ):
             self.__handler_debug.write(f"UEX/Skill version parity lost.", True)
-            self.__handler_debug.write(f"UEX functions will be unavailable for a moment. Recreating data pool ...", True)
-            self.__handler_debug.write(f"Versions: Skill: {old_version_skill} -> {self.__version_skill} | UEX: {old_version_uex} -> {self.__version_uex}")
+            self.__handler_debug.write(
+                f"UEX functions will be unavailable for a moment. Recreating data pool ...",
+                True,
+            )
+            self.__handler_debug.write(
+                f"Versions: Skill: {old_version_skill} -> {self.__version_skill} | UEX: {old_version_uex} -> {self.__version_uex}"
+            )
             self.set_ready(True)
             self.get_database().recreate_database()
         elif force_check:
-            self.__handler_debug.write(f"Version parity is still given. Skill: {old_version_skill} | UEX: {old_version_uex}")
+            self.__handler_debug.write(
+                f"Version parity is still given. Skill: {old_version_skill} | UEX: {old_version_uex}"
+            )
 
     def on_secret_changed(self, secrets: dict[str, any]):
         if "uex" in secrets:
@@ -111,31 +130,67 @@ class Helper:
 
         self.__handler_debug.write("Syncing UEX data with FasterWhisper hotwords ...")
         try:
-            from skills.uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
-            from skills.uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
-            from skills.uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
-            from skills.uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
-            from skills.uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
-            from skills.uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
-            from skills.uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
+            from skills.uexcorp.uexcorp.data_access.city_data_access import (
+                CityDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.commodity_data_access import (
+                CommodityDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.company_data_access import (
+                CompanyDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.item_data_acceess import (
+                ItemDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.moon_data_access import (
+                MoonDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.outpost_data_access import (
+                OutpostDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.planet_data_access import (
+                PlanetDataAccess,
+            )
             from skills.uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
-            from skills.uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
-            from skills.uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
-            from skills.uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
-            from skills.uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+            from skills.uexcorp.uexcorp.data_access.space_station_data_access import (
+                SpaceStationDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.star_system_data_access import (
+                StarSystemDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.terminal_data_access import (
+                TerminalDataAccess,
+            )
+            from skills.uexcorp.uexcorp.data_access.vehicle_data_access import (
+                VehicleDataAccess,
+            )
         except ModuleNotFoundError:
             from uexcorp.uexcorp.data_access.city_data_access import CityDataAccess
-            from uexcorp.uexcorp.data_access.commodity_data_access import CommodityDataAccess
-            from uexcorp.uexcorp.data_access.company_data_access import CompanyDataAccess
+            from uexcorp.uexcorp.data_access.commodity_data_access import (
+                CommodityDataAccess,
+            )
+            from uexcorp.uexcorp.data_access.company_data_access import (
+                CompanyDataAccess,
+            )
             from uexcorp.uexcorp.data_access.item_data_acceess import ItemDataAccess
             from uexcorp.uexcorp.data_access.moon_data_access import MoonDataAccess
-            from uexcorp.uexcorp.data_access.outpost_data_access import OutpostDataAccess
+            from uexcorp.uexcorp.data_access.outpost_data_access import (
+                OutpostDataAccess,
+            )
             from uexcorp.uexcorp.data_access.planet_data_access import PlanetDataAccess
             from uexcorp.uexcorp.data_access.poi_data_access import PoiDataAccess
-            from uexcorp.uexcorp.data_access.space_station_data_access import SpaceStationDataAccess
-            from uexcorp.uexcorp.data_access.star_system_data_access import StarSystemDataAccess
-            from uexcorp.uexcorp.data_access.terminal_data_access import TerminalDataAccess
-            from uexcorp.uexcorp.data_access.vehicle_data_access import VehicleDataAccess
+            from uexcorp.uexcorp.data_access.space_station_data_access import (
+                SpaceStationDataAccess,
+            )
+            from uexcorp.uexcorp.data_access.star_system_data_access import (
+                StarSystemDataAccess,
+            )
+            from uexcorp.uexcorp.data_access.terminal_data_access import (
+                TerminalDataAccess,
+            )
+            from uexcorp.uexcorp.data_access.vehicle_data_access import (
+                VehicleDataAccess,
+            )
 
         data_access_instances = [
             CityDataAccess(),
@@ -151,22 +206,22 @@ class Helper:
             TerminalDataAccess(),
             VehicleDataAccess(),
         ]
+        wingman = self.get_wingmen()
+        hotwords = wingman.config.fasterwhisper.additional_hotwords or []
+        original_hotwords_count = len(hotwords)
 
-        hotwordlist = self.get_wingmen().config.fasterwhisper.hotwords or ""
-        hotwords = hotwordlist.split(",")
-        if "UEX" not in hotwords:
-            hotwords.append("UEX")
-        count = len(hotwords)
+        hotwords.append("UEX")
         for data_access in data_access_instances:
             data = data_access.load()
             for item in data:
                 chunks = str(item).split(" ")
                 for chunk in chunks:
-                    if chunk not in hotwords:
-                        hotwords.append(chunk)
-        count = len(hotwords) - count
-        self.get_wingmen().config.fasterwhisper.hotwords = ", ".join(hotwords)
-        self.__handler_debug.write(f"Synced {count} new hotwords with FasterWhisper.")
+                    hotwords.append(chunk)
+        unique_hotwords = list(set(hotwords))  # remove duplicates
+        self.get_wingmen().config.fasterwhisper.additional_hotwords = unique_hotwords
+        self.__handler_debug.write(
+            f"Synced {len(unique_hotwords) - original_hotwords_count} new hotwords with FasterWhisper."
+        )
 
     def wait(self, seconds: int):
         time.sleep(seconds)
@@ -178,7 +233,9 @@ class Helper:
         self.__is_ready = ready
 
         async def add_loaded_message():
-            await self.get_wingmen().add_assistant_message("UEX skill is now loaded and ready to use.")
+            await self.get_wingmen().add_assistant_message(
+                "UEX skill is now loaded and ready to use."
+            )
 
         if ready and self.get_request_while_not_ready():
             self.__handler_debug.write("UEX functions are available now.", True)
@@ -188,11 +245,15 @@ class Helper:
     def is_loaded(self) -> bool:
         return self.__is_loaded
 
-    def set_loaded(self, loaded: bool = True):#
+    def set_loaded(self, loaded: bool = True):  #
         if loaded:
-            self.__handler_debug.write("===================================== LOAD =====================================")
+            self.__handler_debug.write(
+                "===================================== LOAD ====================================="
+            )
         else:
-            self.__handler_debug.write("===================================== UNLOAD =====================================")
+            self.__handler_debug.write(
+                "===================================== UNLOAD ====================================="
+            )
         self.__is_loaded = loaded
 
     def set_request_while_not_loaded(self, request: bool):
@@ -206,7 +267,9 @@ class Helper:
 
     def end_timer(self, id: str = "default") -> int:
         if id not in self.__timers:
-            self.get_handler_debug().write(f"Tried to end a non existent timer with id '{id}'")
+            self.get_handler_debug().write(
+                f"Tried to end a non existent timer with id '{id}'"
+            )
             return 0
         duration = self.get_timestamp() - self.__timers[id]
         del self.__timers[id]
@@ -241,7 +304,9 @@ class Helper:
 
     def get_version_skill(self, force_check: bool = False) -> str:
         if not self.__version_skill or force_check:
-            with open(path.join(self.__version_file_path, self.__version_file_name), 'r') as f:
+            with open(
+                path.join(self.__version_file_path, self.__version_file_name), "r"
+            ) as f:
                 self.__version_skill = f"{f.read()}"
         return self.__version_skill
 

--- a/templates/configs/defaults.yaml
+++ b/templates/configs/defaults.yaml
@@ -126,6 +126,8 @@ fasterwhisper:
   language_detection_threshold: 0.5
   multilingual: false
   language: ""
+  hotwords: []
+  additional_hotwords: []
 xvasynth:
   voice:
     model_directory: ""

--- a/templates/configs/settings.yaml
+++ b/templates/configs/settings.yaml
@@ -28,6 +28,7 @@ voice_activation:
     no_speech_threshold: 0.7
     language_detection_threshold: 0.5
     multilingual: false
+    hotwords: []
 wingman_pro:
   base_url: https://wingman-api-europe.azurewebsites.net
   region: europe

--- a/templates/configs/settings.yaml
+++ b/templates/configs/settings.yaml
@@ -29,6 +29,7 @@ voice_activation:
     language_detection_threshold: 0.5
     multilingual: false
     hotwords: []
+    additional_hotwords: []
 wingman_pro:
   base_url: https://wingman-api-europe.azurewebsites.net
   region: europe

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -563,10 +563,22 @@ class OpenAiWingman(Wingman):
                     filename=audio_input_wav, config=self.config.whispercpp
                 )
             elif self.config.features.stt_provider == SttProvider.FASTER_WHISPER:
+                hotwords: list[str] = []
+                # add my name
+                hotwords.append(self.name)
+                # add default hotwords
+                default_hotwords = self.config.fasterwhisper.hotwords
+                if default_hotwords and len(default_hotwords) > 0:
+                    hotwords.extend(default_hotwords)
+                # and my additional hotwords
+                wingman_hotwords = self.config.fasterwhisper.additional_hotwords
+                if wingman_hotwords and len(wingman_hotwords) > 0:
+                    hotwords.extend(wingman_hotwords)
+
                 transcript = self.fasterwhisper.transcribe(
                     filename=audio_input_wav,
                     config=self.config.fasterwhisper,
-                    initial_hotwords=self.name,
+                    hotwords=list(set(hotwords)),
                 )
             elif self.config.features.stt_provider == SttProvider.WINGMAN_PRO:
                 if (


### PR DESCRIPTION
Split hotwords into:
- (old) hotwords: The default hotwords set by editing the default config for all Wingmen
- (new) additional_hotwords: Wingmen (and Skills) can set these in addition to the default hotwords and they'll get merged before calling FasterWhisper

Also both lists are now a proper list of strings instead of a comma-separated string which makes it easier to maintain them in code