### PR TITLE
fix streaming TTS with radio sounds, SR for OAI-CompatibleTTS

### DIFF
--- a/providers/inworld.py
+++ b/providers/inworld.py
@@ -217,6 +217,7 @@ class Inworld:
                 sample_rate=int(audio_config["sample_rate_hertz"]),
                 channels=1,  # LINEAR16 is typically mono
                 dtype="int16",  # LINEAR16 uses 16-bit integers
+                use_gain_boost=True, # All streaming PCM TTS providers need this
             )
 
             # Wait for the background thread to complete

--- a/providers/open_ai.py
+++ b/providers/open_ai.py
@@ -212,6 +212,7 @@ class OpenAi(BaseOpenAi):
                         sample_rate=24000,
                         dtype="int16",
                         channels=1,
+                        use_gain_boost=True, # All streaming PCM TTS providers need this
                     )
 
         except APIStatusError as e:
@@ -446,9 +447,10 @@ class OpenAiCompatibleTts:
                         buffer_callback=buffer_callback,
                         config=sound_config,
                         wingman_name=wingman_name,
-                        sample_rate=22050,  # OpenAI TTS default for PCM is 24000 so potential incompatibility here specifically with XTTS2
+                        sample_rate=24000,
                         dtype="int16",
                         channels=1,
+                        use_gain_boost=True, # All streaming PCM TTS providers need this
                     )
 
         except APIStatusError as e:

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -1544,7 +1544,7 @@ class OpenAiWingman(Wingman):
                     model=self.config.openai_compatible_tts.model,
                     speed=(
                         self.config.openai_compatible_tts.speed
-                        if self.config.openai_compatible_tts.speed != 1.0
+                        if self.config.openai_compatible_tts.speed#!= 1.0
                         else NOT_GIVEN
                     ),
                     sound_config=sound_config,


### PR DESCRIPTION
-fix sample rate for openai-compatible tts server (my error, 22050 is the sample rate for input cloning wavs for xtts2, but it actually outputs at 24000 as far as I can tell from reading further)

-Add use_gain_boost=True for Openai, OpenaiCompatible and Inworld TTS providers as it turns out this "azure" hack was actually universal for all PCM streaming audio with pedalboard.