### PR TITLE
Add GROQ support for STT and voice activation providers

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -143,6 +143,7 @@ class SttProvider(Enum):
     WHISPERCPP = "whispercpp"
     FASTER_WHISPER = "fasterwhisper"
     WINGMAN_PRO = "wingman_pro"
+    GROQ = "groq"
 
 
 class VoiceActivationSttProvider(Enum):
@@ -151,6 +152,7 @@ class VoiceActivationSttProvider(Enum):
     WHISPERCPP = "whispercpp"
     FASTER_WHISPER = "fasterwhisper"
     WINGMAN_PRO = "wingman_pro"
+    GROQ = "groq"
 
 
 class ConversationProvider(Enum):

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -763,6 +763,14 @@ class WingmanCore(WebSocketUser):
             openai = OpenAi(api_key=self.secret_keeper.secrets["openai"])
             transcription = openai.transcribe(filename=recording_file)
             text = transcription.text
+        elif provider == VoiceActivationSttProvider.GROQ:
+            # TODO: can't await secret_keeper.retrieve here, so just assume the secret is there...
+            groq = OpenAi(
+                api_key=self.secret_keeper.secrets["groq"],
+                base_url="https://api.groq.com/openai/v1/",
+            )
+            transcription = groq.transcribe(filename=recording_file, model="whisper-large-v3-turbo")
+            text = transcription.text
         elif provider == VoiceActivationSttProvider.FASTER_WHISPER:
             combined_hotwords: list[str] = []
 

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -231,6 +231,7 @@ class OpenAiWingman(Wingman):
                 [
                     self.config.features.conversation_provider
                     == ConversationProvider.GROQ,
+                    self.config.features.stt_provider == SttProvider.GROQ,
                 ]
             )
         elif provider_type == "cerebras":
@@ -967,6 +968,8 @@ class OpenAiWingman(Wingman):
                     )
             elif self.config.features.stt_provider == SttProvider.OPENAI:
                 transcript = self.openai.transcribe(filename=audio_input_wav)
+            elif self.config.features.stt_provider == SttProvider.GROQ:
+                transcript = self.groq.transcribe(filename=audio_input_wav, model="whisper-large-v3-turbo")
         except Exception as e:
             await printr.print_async(
                 f"Error during transcription using '{self.config.features.stt_provider}': {str(e)}",


### PR DESCRIPTION
This pull request adds support for the GROQ speech-to-text (STT) provider across the codebase. The main changes introduce GROQ as a selectable STT provider, update relevant enums, and implement logic for handling transcription with GROQ in the main processing flow.

New provider support:

* Added `GROQ` as an option to both the `SttProvider` and `VoiceActivationSttProvider` enums in `api/enums.py`, enabling it as a selectable provider throughout the application. [[1]](diffhunk://#diff-d4c95450ecbdde3edf5e9df76c7c09b35f3b0a98a947355e90099259cc3049feR146) [[2]](diffhunk://#diff-d4c95450ecbdde3edf5e9df76c7c09b35f3b0a98a947355e90099259cc3049feR155)

Transcription logic updates:

* Implemented logic to handle transcription using GROQ in both the synchronous and asynchronous transcription flows, utilizing the `whisper-large-v3-turbo` model and the correct GROQ API endpoint. [[1]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827R766-R773) [[2]](diffhunk://#diff-ed52266b26698a5faa82734d566aa80aa927a7ceed409510c315c6d34d4d85eaR971-R972)

Provider usage detection:

* Updated the provider usage logic in `wingmen/open_ai_wingman.py` to recognize when GROQ is selected as the STT provider.