### PR TITLE
Improve thread management and cleanup across components:

### DIFF
--- a/providers/faster_whisper.py
+++ b/providers/faster_whisper.py
@@ -55,9 +55,16 @@ class FasterWhisper:
                     torch.cuda.synchronize()
             except ImportError:
                 pass  # torch not available, skip CUDA cleanup
+            except Exception as e:
+                # any other CUDA-related cleanup error should not crash model reload
+                self.printr.print(
+                    f"FasterWhisper: CUDA cleanup failed during model unload: {e}",
+                    server_only=True,
+                    color=LogType.WARNING,
+                )
 
     def __update_model(self):
-        # Unload existing model first to free VRAM
+        # Unload the existing model first to free VRAM
         self.__unload_model()
 
         if self.is_windows:

--- a/providers/faster_whisper.py
+++ b/providers/faster_whisper.py
@@ -1,5 +1,6 @@
 from os import path
 import platform
+import gc
 from typing import Optional
 from faster_whisper import WhisperModel
 from api.enums import LogType
@@ -23,6 +24,7 @@ class FasterWhisper:
     ):
         self.printr = Printr()
         self.settings = settings
+        self.model: Optional[WhisperModel] = None
 
         self.is_windows = platform.system() == "Windows"
         if self.is_windows:
@@ -32,7 +34,32 @@ class FasterWhisper:
 
         self.__update_model()
 
+    def __unload_model(self):
+        """Unload the current model to free VRAM."""
+        if self.model is not None:
+            self.printr.print(
+                "FasterWhisper: Unloading current model to free VRAM...",
+                server_only=True,
+            )
+            del self.model
+            self.model = None
+
+            # Force garbage collection to release memory
+            gc.collect()
+
+            # Clear CUDA cache if using GPU
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                    torch.cuda.synchronize()
+            except ImportError:
+                pass  # torch not available, skip CUDA cleanup
+
     def __update_model(self):
+        # Unload existing model first to free VRAM
+        self.__unload_model()
+
         if self.is_windows:
             model_file = path.join(self.models_dir, (self.settings.model_size))
             model = model_file if path.exists(model_file) else self.settings.model_size
@@ -100,6 +127,10 @@ class FasterWhisper:
         return None
 
     def update_settings(self, settings: FasterWhisperSettings):
+        if self.settings == settings:
+            self.printr.print("FasterWhisper settings updated.", server_only=True)
+            return
+        self.printr.print(f"FasterWhisper settings updated, reloading model..", server_only=True)
         self.settings = settings
         self.__update_model()
 

--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -167,8 +167,11 @@ class CommandHandler:
             server_only=True,
         )
 
+        # Stop the joystick thread in wingman_core to prevent event conflicts
+        # Both loops would otherwise compete for pygame events
+        await self.core._stop_joystick_thread()
+
         self.recorded_keys = []
-        was_init = pygame.get_init()
         pygame.init()
         joysticks = [
             pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
@@ -200,8 +203,12 @@ class CommandHandler:
 
         await self.handle_stop_recording(stop_command, None)
 
-        if not was_init:
+        # Always quit pygame to ensure clean state - refresh_input_hooks will restart it if needed
+        if pygame.get_init():
             pygame.quit()
+
+        # Restart joystick thread if there are configured joystick buttons
+        await self.core.refresh_input_hooks()
 
     async def handle_record_keyboard_actions(
         self, command: RecordKeyboardActionsCommand, websocket: WebSocket

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -1054,6 +1054,9 @@ class ConfigService:
         else:
             self.printr.print(text=message, server_only=True)
 
+        # Notify listeners that a wingman config was saved (for input hook refresh)
+        await self.config_events.publish("wingman_config_saved", merged_config)
+
     @staticmethod
     def _merge_skill_configs(
         existing: list[SkillConfig] | None,

--- a/services/mcp_client.py
+++ b/services/mcp_client.py
@@ -9,14 +9,26 @@ MCP servers expose tools that can be used by the LLM, similar to skills.
 ARCHITECTURE NOTE:
 The MCP SDK uses anyio task groups internally for its transports. The context
 managers (streamablehttp_client, etc.) spawn background tasks for reading/writing.
-These tasks must remain active while the session is in use. We use two strategies:
+These tasks must remain active while the session is in use.
 
-1. For HTTP transport: Make per-call connections since HTTP is stateless anyway
-2. For STDIO/SSE: Keep a background task running that manages the session lifecycle
+For SSE transport specifically:
+- The SSE client runs an anyio task group with a reader task that continuously
+  listens for server-sent events. This can interfere with the main event loop
+  if not properly isolated.
+- We run SSE connections in a dedicated background thread with its own event loop
+  to completely isolate them from the main application event loop (keyboard, etc.)
+- Tool calls are executed via thread-safe communication with the SSE thread
+
+For HTTP/STDIO:
+- HTTP: Per-call connections (stateless)
+- STDIO: Persistent connections (local process, minimal overhead)
 """
 
 import asyncio
+import concurrent.futures
 import json
+import logging
+import threading
 import traceback
 from dataclasses import dataclass, field
 from typing import Any, Optional
@@ -35,6 +47,13 @@ try:
     from mcp.client.sse import sse_client
 
     MCP_AVAILABLE = True
+
+    # Suppress verbose INFO logs from MCP SDK and its dependencies
+    logging.getLogger("mcp").setLevel(logging.WARNING)
+    logging.getLogger("mcp.client.sse").setLevel(logging.WARNING)
+    logging.getLogger("mcp.client.streamable_http").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
 except ImportError:
     MCP_AVAILABLE = False
     printr.print(
@@ -49,19 +68,26 @@ class McpConnection:
     """Represents an active connection to an MCP server."""
 
     config: McpServerConfig
-    session: Optional[Any] = None  # ClientSession when connected (not used for HTTP)
+    session: Optional[Any] = None  # ClientSession when connected (STDIO/SSE)
     tools: list[McpToolInfo] = field(default_factory=list)
     is_connected: bool = False
     error: Optional[str] = None
 
-    # HTTP connections store merged headers for per-call connections
-    _merged_headers: dict[str, str] = field(default_factory=dict)
+    # HTTP/SSE connections store merged headers for per-call connections
+    merged_headers: dict[str, str] = field(default_factory=dict)
 
-    # Connection resources that need cleanup (for STDIO/SSE only)
-    _read_stream: Any = None
-    _write_stream: Any = None
-    _context_manager: Any = None
-    _session_context: Any = None
+    # Connection resources that need cleanup (for STDIO only - HTTP uses per-call)
+    read_stream: Any = None
+    write_stream: Any = None
+    context_manager: Any = None
+    session_context: Any = None
+
+    # SSE-specific: dedicated thread with its own event loop
+    sse_thread: Optional[threading.Thread] = None
+    sse_loop: Optional[asyncio.AbstractEventLoop] = None
+    sse_shutdown_event: Optional[threading.Event] = None
+    sse_ready_event: Optional[threading.Event] = None
+    sse_error: Optional[str] = None
 
 
 class McpClient:
@@ -71,8 +97,11 @@ class McpClient:
     Supports three transport types:
     - HTTP: For hosted MCP servers (like Context7, Svelte MCP)
       Uses per-call connections since HTTP is stateless.
-    - STDIO: For local processes (like Docker MCP)
     - SSE: For Server-Sent Events based servers
+      Runs in a dedicated background thread with its own event loop to avoid
+      blocking the main event loop (keyboard handling, etc.)
+    - STDIO: For local processes (like Docker MCP)
+      Maintains persistent connections since local process overhead is minimal.
 
     Usage:
         client = McpClient(wingman_name="MyWingman")
@@ -237,7 +266,7 @@ class McpClient:
             return
 
         # Store headers for later use in tool calls
-        connection._merged_headers = headers
+        connection.merged_headers = headers
 
         try:
             # Use proper async with context to verify connection and get tools
@@ -305,14 +334,14 @@ class McpClient:
             streams = await context_manager.__aenter__()
             read_stream, write_stream = streams
 
-            connection._context_manager = context_manager
-            connection._read_stream = read_stream
-            connection._write_stream = write_stream
+            connection.context_manager = context_manager
+            connection.read_stream = read_stream
+            connection.write_stream = write_stream
 
             # Create and initialize session
             session = ClientSession(read_stream, write_stream)
             session_context = await session.__aenter__()
-            connection._session_context = session
+            connection.session_context = session
 
             await session.initialize()
             connection.session = session
@@ -328,45 +357,118 @@ class McpClient:
     async def _connect_sse(
         self, connection: McpConnection, headers: dict[str, str]
     ) -> None:
-        """Connect using SSE (Server-Sent Events) transport."""
+        """
+        Connect using SSE (Server-Sent Events) transport.
+
+        SSE connections run in a dedicated background thread with their own event loop.
+        This completely isolates them from the main event loop, preventing any
+        interference with keyboard handling and other async operations.
+
+        The thread maintains a persistent connection and handles tool calls via
+        thread-safe futures.
+        """
         config = connection.config
         if not config.url:
             connection.error = "URL is required for SSE transport"
             return
 
-        # Store headers for later use in tool calls
-        connection._merged_headers = headers
+        # Store headers for later use
+        connection.merged_headers = headers
 
-        try:
-            # Create the SSE client context
-            context_manager = sse_client(
-                url=config.url,
-                headers=headers if headers else None,
-            )
+        # Create thread synchronization primitives
+        connection.sse_shutdown_event = threading.Event()
+        connection.sse_ready_event = threading.Event()
+        connection.sse_error = None
 
-            # Enter the context to get streams
-            streams = await context_manager.__aenter__()
-            read_stream, write_stream = streams
+        # Storage for the session (will be set by the SSE thread)
+        sse_session_holder: dict[str, Any] = {"session": None, "loop": None}
 
-            connection._context_manager = context_manager
-            connection._read_stream = read_stream
-            connection._write_stream = write_stream
+        def run_sse_event_loop():
+            """Run SSE connection in a dedicated thread with its own event loop."""
 
-            # Create and initialize session
-            session = ClientSession(read_stream, write_stream)
-            session_context = await session.__aenter__()
-            connection._session_context = session
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            connection.sse_loop = loop
 
-            await session.initialize()
-            connection.session = session
-            connection.is_connected = True
+            async def maintain_sse_connection():
+                try:
+                    async with sse_client(
+                        url=config.url,
+                        headers=headers if headers else None,
+                        timeout=30,
+                        sse_read_timeout=300,  # 5 min keep-alive
+                    ) as (read_stream, write_stream):
+                        async with ClientSession(read_stream, write_stream) as session:
+                            await session.initialize()
 
-            # Fetch available tools
-            await self._fetch_tools(connection)
+                            # Fetch tools
+                            tools_response = await session.list_tools()
+                            connection.tools = []
 
-        except Exception as e:
-            await self._cleanup_connection(connection)
-            raise
+                            for tool in tools_response.tools:
+                                prefixed_name = f"mcp_{connection.config.name}_{tool.name}"
+                                input_schema = None
+                                if tool.inputSchema:
+                                    input_schema = (
+                                        dict(tool.inputSchema)
+                                        if hasattr(tool.inputSchema, "items")
+                                        else tool.inputSchema
+                                    )
+
+                                tool_info = McpToolInfo(
+                                    name=tool.name,
+                                    prefixed_name=prefixed_name,
+                                    description=tool.description
+                                    or f"Tool from {connection.config.display_name}",
+                                    server_name=connection.config.name,
+                                    input_schema=input_schema,
+                                )
+                                connection.tools.append(tool_info)
+
+                            # Store session reference for tool calls
+                            sse_session_holder["session"] = session
+                            sse_session_holder["loop"] = loop
+                            connection.session = session
+                            connection.is_connected = True
+
+                            # Signal that we're ready
+                            connection.sse_ready_event.set()
+
+                            # Keep the connection alive until shutdown is requested
+                            while not connection.sse_shutdown_event.is_set():
+                                await asyncio.sleep(1.0)
+
+                except Exception as e:
+                    connection.sse_error = str(e)
+                    connection.is_connected = False
+                finally:
+                    connection.sse_ready_event.set()  # Unblock waiting caller
+                    sse_session_holder["session"] = None
+                    connection.session = None
+
+            try:
+                loop.run_until_complete(maintain_sse_connection())
+            finally:
+                loop.close()
+                connection.sse_loop = None
+
+        # Start the SSE thread
+        connection.sse_thread = threading.Thread(
+            target=run_sse_event_loop,
+            name=f"MCP-SSE-{config.name}",
+            daemon=True,
+        )
+        connection.sse_thread.start()
+
+        # Wait for the connection to be ready (with timeout)
+        ready = connection.sse_ready_event.wait(timeout=35)
+        if not ready:
+            connection.sse_shutdown_event.set()
+            connection.error = "SSE connection timeout"
+            raise TimeoutError("SSE connection timeout")
+
+        if connection.sse_error:
+            raise Exception(connection.sse_error)
 
     async def _fetch_tools(self, connection: McpConnection) -> None:
         """Fetch and store available tools from the connected server."""
@@ -424,35 +526,60 @@ class McpClient:
             # Note: State change notification is handled by McpRegistry
 
     async def disconnect_all(self) -> None:
-        """Disconnect from all MCP servers."""
+        """Disconnect from all MCP servers in parallel."""
         connections = list(self._connections.values())
-        for connection in connections:
-            await self.disconnect(connection)
+        if connections:
+            await asyncio.gather(*[self.disconnect(conn) for conn in connections])
 
     async def _cleanup_connection(self, connection: McpConnection) -> None:
-        """Clean up connection resources."""
+        """Clean up connection resources with timeouts to prevent blocking."""
         connection.is_connected = False
 
-        # Close session
-        if connection._session_context:
+        # Handle SSE thread cleanup
+        if connection.sse_shutdown_event:
+            connection.sse_shutdown_event.set()
+
+        if connection.sse_thread and connection.sse_thread.is_alive():
+            # Run thread.join in executor to avoid blocking the event loop
+            def join_thread():
+                if connection.sse_thread:
+                    connection.sse_thread.join(timeout=3.0)
+
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, join_thread)
+            connection.sse_thread = None
+
+        connection.sse_loop = None
+        connection.sse_shutdown_event = None
+        connection.sse_ready_event = None
+        connection.sse_error = None
+
+        # Close session with timeout (for STDIO)
+        if connection.session_context:
             try:
-                await connection._session_context.__aexit__(None, None, None)
-            except Exception:
+                await asyncio.wait_for(
+                    connection.session_context.__aexit__(None, None, None),
+                    timeout=5.0,
+                )
+            except (asyncio.TimeoutError, Exception):
                 pass
-            connection._session_context = None
+            connection.session_context = None
 
         connection.session = None
 
-        # Close transport context
-        if connection._context_manager:
+        # Close transport context with timeout (for STDIO)
+        if connection.context_manager:
             try:
-                await connection._context_manager.__aexit__(None, None, None)
-            except Exception:
+                await asyncio.wait_for(
+                    connection.context_manager.__aexit__(None, None, None),
+                    timeout=5.0,
+                )
+            except (asyncio.TimeoutError, Exception):
                 pass
-            connection._context_manager = None
+            connection.context_manager = None
 
-        connection._read_stream = None
-        connection._write_stream = None
+        connection.read_stream = None
+        connection.write_stream = None
 
     async def _call_tool_http(
         self,
@@ -473,7 +600,7 @@ class McpClient:
 
         async with streamablehttp_client(
             url=config.url,
-            headers=connection._merged_headers if connection._merged_headers else None,
+            headers=connection.merged_headers if connection.merged_headers else None,
             timeout=timeout,
             sse_read_timeout=timeout,
         ) as (read_stream, write_stream, _):
@@ -517,23 +644,38 @@ class McpClient:
         timeout: float = 60.0,
     ) -> str:
         """
-        Call a tool on an SSE MCP server using a fresh connection per call.
+        Call a tool on an SSE MCP server using the persistent connection.
 
-        SSE transport uses per-call connections because:
-        1. The MCP SDK's anyio task groups require proper context manager usage
-        2. Fresh connections avoid blocking issues with persistent connections
+        The SSE connection runs in a dedicated thread. We submit the tool call
+        to that thread's event loop and wait for the result via a thread-safe
+        future.
         """
-        config = connection.config
+        if not connection.sse_loop or not connection.session:
+            raise RuntimeError("SSE connection is not active")
 
-        async with sse_client(
-            url=config.url,
-            headers=connection._merged_headers if connection._merged_headers else None,
-            timeout=timeout,
-        ) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                result = await session.call_tool(tool_name, arguments)
-                return self._parse_tool_result(result)
+        # Create a future to get the result from the SSE thread
+        loop = asyncio.get_event_loop()
+
+        async def call_in_sse_thread():
+            result = await connection.session.call_tool(tool_name, arguments)
+            return self._parse_tool_result(result)
+
+        # Schedule the coroutine in the SSE thread's event loop
+        future = asyncio.run_coroutine_threadsafe(
+            call_in_sse_thread(),
+            connection.sse_loop,
+        )
+
+        try:
+            # Wait for the result with timeout
+            result = await asyncio.wait_for(
+                loop.run_in_executor(None, future.result, timeout),
+                timeout=timeout + 5,
+            )
+            return result
+        except concurrent.futures.TimeoutError:
+            future.cancel()
+            raise asyncio.TimeoutError(f"SSE tool call timed out: {tool_name}")
 
     def _parse_tool_result(self, result) -> str:
         """Parse a tool result into a string."""
@@ -578,8 +720,8 @@ class McpClient:
             return f"Error: Not connected to MCP server {connection.config.name}"
 
         try:
-            # Use per-call connections for HTTP, STDIO, and SSE to avoid
-            # anyio task group blocking issues
+            # HTTP/STDIO: per-call connections to avoid anyio task group issues
+            # SSE: uses persistent connection in dedicated thread (thread-safe)
             if connection.config.type == McpTransportType.HTTP:
                 result_str = await asyncio.wait_for(
                     self._call_tool_http(connection, tool_name, arguments, timeout),
@@ -650,6 +792,6 @@ class McpClient:
         if connection.is_connected:
             if connection.config.type == McpTransportType.HTTP:
                 # For HTTP, reconnect to refresh tools
-                await self._connect_http(connection, connection._merged_headers)
+                await self._connect_http(connection, connection.merged_headers)
             else:
                 await self._fetch_tools(connection)

--- a/services/mcp_client.py
+++ b/services/mcp_client.py
@@ -21,7 +21,7 @@ For SSE transport specifically:
 
 For HTTP/STDIO:
 - HTTP: Per-call connections (stateless)
-- STDIO: Persistent connections (local process, minimal overhead)
+- STDIO: Per-call connections (local process, to avoid anyio task group issues)
 """
 
 import asyncio
@@ -465,9 +465,11 @@ class McpClient:
         if not ready:
             connection.sse_shutdown_event.set()
             connection.error = "SSE connection timeout"
+            await self._cleanup_connection(connection)
             raise TimeoutError("SSE connection timeout")
 
         if connection.sse_error:
+            await self._cleanup_connection(connection)
             raise Exception(connection.sse_error)
 
     async def _fetch_tools(self, connection: McpConnection) -> None:
@@ -547,6 +549,15 @@ class McpClient:
 
             loop = asyncio.get_event_loop()
             await loop.run_in_executor(None, join_thread)
+
+            # if the thread is still alive after join timeout, we will issue a warning
+            if connection.sse_thread and connection.sse_thread.is_alive():
+                printr.print(
+                    f"SSE thread for {connection.config.name} did not stop within timeout",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+
             connection.sse_thread = None
 
         connection.sse_loop = None
@@ -562,6 +573,7 @@ class McpClient:
                     timeout=5.0,
                 )
             except (asyncio.TimeoutError, Exception):
+                # the error during session cleanup is ignored - connection will be closed anyway
                 pass
             connection.session_context = None
 
@@ -574,8 +586,20 @@ class McpClient:
                     connection.context_manager.__aexit__(None, None, None),
                     timeout=5.0,
                 )
-            except (asyncio.TimeoutError, Exception):
-                pass
+            except asyncio.TimeoutError:
+                # Timeout is acceptable during cleanup - the process will still be terminated
+                printr.print(
+                    f"Timeout closing STDIO connection for {connection.config.name}",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+            except Exception as e:
+                # Log other errors during cleanup but do not propagate
+                printr.print(
+                    f"Error closing STDIO connection for {connection.config.name}: {e}",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
             connection.context_manager = None
 
         connection.read_stream = None

--- a/services/mcp_registry.py
+++ b/services/mcp_registry.py
@@ -208,8 +208,13 @@ class McpRegistry:
 
         return connection
 
-    async def unregister_server(self, server_name: str) -> None:
-        """Disconnect and remove an MCP server."""
+    async def unregister_server(self, server_name: str, notify: bool = True) -> None:
+        """Disconnect and remove an MCP server.
+
+        Args:
+            server_name: Name of the server to unregister
+            notify: Whether to notify UI of state change (set False during batch operations)
+        """
         connection = self._connections.get(server_name)
         if connection:
             # Remove tool mappings
@@ -222,14 +227,24 @@ class McpRegistry:
             self._manifests.pop(server_name, None)
             self._active_servers.discard(server_name)
 
-            # Notify UI that MCP state has changed
-            await self._notify_state_changed()
+            # Notify UI that MCP state has changed (skip during batch operations)
+            if notify:
+                await self._notify_state_changed()
 
     async def clear(self) -> None:
-        """Disconnect from all servers and clear the registry."""
+        """Disconnect from all servers and clear the registry.
+
+        This batches disconnections and only sends a single UI notification at the end.
+        """
         server_names = list(self._connections.keys())
-        for server_name in server_names:
-            await self.unregister_server(server_name)
+        if not server_names:
+            return
+
+        # Disconnect all servers in parallel without individual notifications
+        await asyncio.gather(*[self.unregister_server(name, notify=False) for name in server_names])
+
+        # Send a single notification after all disconnections complete
+        await self._notify_state_changed()
 
     def get_connected_servers(self) -> list[McpServerManifest]:
         """Get all connected MCP server manifests."""

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -348,6 +348,10 @@ class WingmanCore(WebSocketUser):
 
         self.key_events = {}
 
+        # Joystick thread management
+        self._joystick_thread: Optional[threading.Thread] = None
+        self._joystick_loop: Optional[asyncio.AbstractEventLoop] = None
+
         self.settings_service = SettingsService(
             config_manager=config_manager, config_service=self.config_service
         )
@@ -506,10 +510,13 @@ class WingmanCore(WebSocketUser):
             await asyncio.sleep(0.01)
 
     def init_joystick(self, config: Config):
+        # Stop any existing joystick thread first to prevent thread accumulation
+        self._stop_joystick_thread()
 
         def run_async_process():
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
+            self._joystick_loop = loop  # Store reference for cleanup
             try:
                 # Create a task for start_joysticks instead of running it directly
                 loop.create_task(self.start_joysticks(config))
@@ -518,8 +525,30 @@ class WingmanCore(WebSocketUser):
             finally:
                 loop.close()
 
-        play_thread = threading.Thread(target=run_async_process)
-        play_thread.start()
+        self._joystick_thread = threading.Thread(target=run_async_process, daemon=True)
+        self._joystick_thread.name = "JoystickEventLoop"
+        self._joystick_thread.start()
+
+    def _stop_joystick_thread(self):
+        """Stop the joystick event loop and thread."""
+        if self._joystick_loop and self._joystick_loop.is_running():
+            # Schedule the loop to stop from another thread
+            try:
+                self._joystick_loop.call_soon_threadsafe(self._joystick_loop.stop)
+            except RuntimeError:
+                pass  # Loop may already be closed
+
+        if self._joystick_thread and self._joystick_thread.is_alive():
+            self._joystick_thread.join(timeout=1.0)
+            if self._joystick_thread.is_alive():
+                self.printr.print(
+                    "WARNING: Joystick thread did not stop in time",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+
+        self._joystick_thread = None
+        self._joystick_loop = None
 
     async def initialize_tower(self, config_dir_info: ConfigWithDirInfo):
         if not self.is_client_logged_in:
@@ -578,6 +607,16 @@ class WingmanCore(WebSocketUser):
                 await wingman.unload()
             self.tower = None
             self.config_service.set_tower(None)
+
+            # Stop joystick thread to prevent thread accumulation on reload
+            self._stop_joystick_thread()
+
+            # Unhook mouse to prevent duplicate hooks
+            try:
+                mouse.unhook_all()
+            except Exception:
+                pass  # May fail if no hooks are registered
+
             self.printr.print(
                 "Tower unloaded.",
                 server_only=True,

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -320,6 +320,9 @@ class WingmanCore(WebSocketUser):
         self.config_service.config_events.subscribe(
             "config_loaded", self.initialize_tower
         )
+        self.config_service.config_events.subscribe(
+            "wingman_config_saved", self.on_wingman_config_saved
+        )
 
         self.secret_keeper: SecretKeeper = SecretKeeper()
 
@@ -351,6 +354,7 @@ class WingmanCore(WebSocketUser):
         # Joystick thread management
         self._joystick_thread: Optional[threading.Thread] = None
         self._joystick_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._mouse_hook_registered: bool = False
 
         self.settings_service = SettingsService(
             config_manager=config_manager, config_service=self.config_service
@@ -509,9 +513,9 @@ class WingmanCore(WebSocketUser):
             # Add a small sleep to prevent the loop from consuming too much CPU
             await asyncio.sleep(0.01)
 
-    def init_joystick(self, config: Config):
+    async def init_joystick(self, config: Config):
         # Stop any existing joystick thread first to prevent thread accumulation
-        self._stop_joystick_thread()
+        await self._stop_joystick_thread()
 
         def run_async_process():
             loop = asyncio.new_event_loop()
@@ -529,7 +533,7 @@ class WingmanCore(WebSocketUser):
         self._joystick_thread.name = "JoystickEventLoop"
         self._joystick_thread.start()
 
-    def _stop_joystick_thread(self):
+    async def _stop_joystick_thread(self):
         """Stop the joystick event loop and thread."""
         if self._joystick_loop and self._joystick_loop.is_running():
             # Schedule the loop to stop from another thread
@@ -539,7 +543,7 @@ class WingmanCore(WebSocketUser):
                 pass  # Loop may already be closed
 
         if self._joystick_thread and self._joystick_thread.is_alive():
-            self._joystick_thread.join(timeout=1.0)
+            await asyncio.to_thread(self._joystick_thread.join, 1.0)
             if self._joystick_thread.is_alive():
                 self.printr.print(
                     "WARNING: Joystick thread did not stop in time",
@@ -547,8 +551,78 @@ class WingmanCore(WebSocketUser):
                     server_only=True,
                 )
 
+        # Clean up pygame to allow fresh initialization later
+        if pygame.get_init():
+            try:
+                pygame.quit()
+            except Exception:
+                pass  # May fail if pygame is in an inconsistent state
+
         self._joystick_thread = None
         self._joystick_loop = None
+
+    async def refresh_input_hooks(self):
+        """Refresh mouse and joystick hooks based on current wingman configurations.
+
+        This method should be called when a wingman's activation key (mouse button or
+        joystick button) configuration changes to ensure the new keys take effect immediately.
+
+        Note: The on_press handler already dynamically checks tower.wingmen for activation keys,
+        so we only need to ensure the hooks are registered and joystick thread has latest config.
+        """
+        if not self.tower:
+            return
+
+        # Check if any wingman has a mouse button configured
+        needs_mouse = any(
+            wingman.get_record_mouse_button() for wingman in self.tower.wingmen
+        )
+
+        # Register mouse hook if needed and not already registered
+        if needs_mouse and not self._mouse_hook_registered:
+            mouse.hook(self.on_mouse)
+            self._mouse_hook_registered = True
+            self.printr.print(
+                "Mouse hook registered for new activation key.",
+                color=LogType.INFO,
+                server_only=True,
+            )
+
+        # Check if any wingman has a joystick button configured
+        needs_joystick = any(
+            wingman.get_record_joystick_button() for wingman in self.tower.wingmen
+        )
+
+        # Also check for cancel TTS joystick button in settings
+        cancel_tts_joystick_button = getattr(
+            self.settings_service.settings, "cancel_tts_joystick_button", None
+        )
+        if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
+            needs_joystick = True
+
+        joystick_running = self._joystick_thread is not None and self._joystick_thread.is_alive()
+
+        if needs_joystick:
+            # Restart joystick thread to pick up new button configurations
+            # The joystick loop uses a static list of configs, so we must restart it
+            # Build current config from tower wingmen since tower.config may be stale
+            current_wingmen = {
+                wingman.name: wingman.config for wingman in self.tower.wingmen
+            }
+            current_config = self.tower.config.model_copy(update={"wingmen": current_wingmen})
+            await self.init_joystick(current_config)
+            self.printr.print(
+                "Joystick hooks refreshed for new activation key.",
+                color=LogType.INFO,
+                server_only=True,
+            )
+        elif joystick_running and not needs_joystick:
+            # No joystick needed anymore, stop the thread
+            await self._stop_joystick_thread()
+
+    async def on_wingman_config_saved(self, wingman_config):
+        """Called when a wingman config is saved. Refreshes input hooks if needed."""
+        await self.refresh_input_hooks()
 
     async def initialize_tower(self, config_dir_info: ConfigWithDirInfo):
         if not self.is_client_logged_in:
@@ -569,8 +643,9 @@ class WingmanCore(WebSocketUser):
         # Register hooks
         if self.is_mouse_configured(config):
             mouse.hook(self.on_mouse)
+            self._mouse_hook_registered = True
         if self.is_joystick_configured(config):
-            self.init_joystick(config)
+            await self.init_joystick(config)
 
         self.tower = Tower(
             config=config,
@@ -609,11 +684,12 @@ class WingmanCore(WebSocketUser):
             self.config_service.set_tower(None)
 
             # Stop joystick thread to prevent thread accumulation on reload
-            self._stop_joystick_thread()
+            await self._stop_joystick_thread()
 
             # Unhook mouse to prevent duplicate hooks
             try:
                 mouse.unhook_all()
+                self._mouse_hook_registered = False
             except Exception:
                 pass  # May fail if no hooks are registered
 

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -217,6 +217,8 @@ class OpenAiWingman(Wingman):
                     self.config.features.stt_provider == SttProvider.OPENAI,
                     self.config.features.conversation_provider
                     == ConversationProvider.OPENAI,
+                    self.config.features.image_generation_provider
+                    == ImageGenerationProvider.OPENAI,
                 ]
             )
         elif provider_type == "mistral":
@@ -295,6 +297,8 @@ class OpenAiWingman(Wingman):
                     == ConversationProvider.WINGMAN_PRO,
                     self.config.features.tts_provider == TtsProvider.WINGMAN_PRO,
                     self.config.features.stt_provider == SttProvider.WINGMAN_PRO,
+                    self.config.features.image_generation_provider
+                    == ImageGenerationProvider.WINGMAN_PRO,
                 ]
             )
         elif provider_type == "perplexity":

--- a/wingmen/wingman.py
+++ b/wingmen/wingman.py
@@ -840,6 +840,7 @@ class Wingman:
 
             thread = threading.Thread(target=start_thread, args=(function, *args))
             thread.name = function.__name__
+            thread.daemon = True  # Mark as daemon so it dies when main process exits
             thread.start()
             return thread
         except Exception as e:
@@ -973,11 +974,12 @@ class Wingman:
         self.tower.save_wingman_commands(self.name)
 
     async def update_settings(self, settings: SettingsConfig):
-        """Update the settings of the Wingman. This method should always be called when the user Settings have changed."""
+        """Update the settings of the Wingman. This method should always be called when the user Settings have changed.
+        """
         self.settings = settings
-        await self.init_skills()
-        # Also reload MCPs if the wingman supports them
-        if hasattr(self, "init_mcps"):
-            await self.init_mcps()
+
+        # Propagate settings changes to already-loaded skills
+        for skill in self.skills:
+            skill.settings = settings
 
         printr.print(f"Wingman {self.name}'s settings changed", server_only=True)


### PR DESCRIPTION
- Refactor joystick thread handling in `wingman_core` to prevent thread accumulation.
- Introduce dedicated threads for SSE connections in `mcp_client` to isolate event loops and improve resource management.
- Add proper cleanup logic for threads and resources in disconnect methods.
- Enhance `faster_whisper` model unloading with GPU memory cleanup and reloading logic.
- remove skill and mcp re-init on global settings change and update skill settings while they stay loaded
- fixed recording and chaning of joystick ptt buttons
- fix wingman pro & openai detection as image generation provider