### PR TITLE
add command matcher to msfs control skill

### DIFF
--- a/skills/msfs2020_control/command_matcher/command_matcher.py
+++ b/skills/msfs2020_control/command_matcher/command_matcher.py
@@ -1,0 +1,104 @@
+import os
+import sys
+from rapidfuzz import process, fuzz, utils
+from SimConnect.EventList import AircraftEvents
+from SimConnect.RequestList import AircraftRequests
+
+# Mock SimConnect to avoid instantiating additional SimConnect for no reason
+class MockSimConnect:
+    def new_request_id(self):
+        class ID: value = 0
+        return ID()
+    def new_def_id(self):
+        class ID: value = 0
+        return ID()
+    def map_to_sim_event(self, deff): return 0
+    def send_event(self, event, value): pass
+    def get_data(self, request): return False
+    def IsHR(self, err, val): return True
+    def new_event_id(self): return 0
+    @property
+    def dll(self):
+        class DLL:
+            def ClearDataDefinition(self, *args): pass
+            def AddToDataDefinition(self, *args): pass
+            def GetLastSentPacketID(self, *args): pass
+        return DLL()
+    def __init__(self):
+        self.Requests = {}
+        self.Facilities = []
+        self.hSimConnect = 0
+
+# Class that attempt to provide a list of SimConnectcommands to the LLM that may match user intent
+class CommandMatcher:
+    def __init__(self):
+        self.all_commands = self._load_commands()
+        # Pre-calculate search strings to make matching faster
+        self.match_pool = [
+            f"{c['name']} {c['description']}".lower() 
+            for c in self.all_commands
+        ]
+
+    def _load_commands(self):
+        commands = []
+        sm = MockSimConnect()
+        
+        # 1. Extract Events
+        try:
+            events_obj = AircraftEvents(sm)
+            for category in events_obj.list:
+                cat_name = category.__class__.__name__.replace("_AircraftEvents__", "")
+                for entry in category.list:
+                    name = entry[0].decode() if isinstance(entry[0], bytes) else str(entry[0])
+                    commands.append({
+                        "name": name, "description": entry[1], 
+                        "type": "Event", "category": cat_name
+                    })
+        except Exception: 
+            pass
+
+        # 2. Extract Requests
+        try:
+            requests_obj = AircraftRequests(sm)
+            for category in requests_obj.list:
+                cat_name = category.__class__.__name__.replace("_AircraftRequests__", "")
+                for name, entry in category.list.items():
+                    commands.append({
+                        "name": name, "description": entry[0], 
+                        "type": "SimVar", "category": cat_name
+                    })
+        except Exception: 
+            pass
+        
+        return commands
+
+    def find_matches(self, user_input, threshold=40, limit=15):
+        if not user_input:
+            return []
+
+        # Perform Fuzzy Match using token_set_ratio ignores word order and handles extra words (like numbers) better
+        results = process.extract(
+            user_input,
+            self.match_pool,
+            scorer=fuzz.token_set_ratio,
+            processor=utils.default_process,
+            limit=limit,
+        )
+
+        final_results = []
+        for _, score, idx in results:
+            
+            # Create a shallow copy to avoid any "mutability trap"
+            cmd = self.all_commands[idx].copy()
+            cmd["match_score"] = score
+            final_results.append(cmd)
+
+        matches = sorted(final_results, key=lambda x: x['match_score'], reverse=True)
+        return matches
+
+    def matches_as_string(self, matches=[]):
+        matches_string = ""
+        for i, m in enumerate(matches, 1):
+            matches_string+=f"{i}. [{m['type']}] {m['name']}\n"
+            matches_string+=f"   Desc: {m['description']}\n\n"
+        return matches_string

--- a/skills/msfs2020_control/default_config.yaml
+++ b/skills/msfs2020_control/default_config.yaml
@@ -8,8 +8,8 @@ tags:
   - Game
   - MSFS
 description:
-  en: Control and retrieve data from MSFS2020 dynamically using SimConnect.
-  de: Steuern und Abrufen von Daten aus MSFS2020 dynamisch mit SimConnect.
+  en: Control and retrieve data from MSFS2020/2024 dynamically using SimConnect.
+  de: Steuern und Abrufen von Daten aus MSFS2020/2024 dynamisch mit SimConnect.
 discovery_keywords:
   - flight simulator
   - altitude
@@ -19,10 +19,13 @@ discovery_keywords:
   - instruments
   - aircraft
   - heading
+  - plane
+  - throttle
+  - flaps
 discoverable_by_default: false
 hint:
-  en: This skill can retrieve data and perform actions in the MSFS2020 simulator based on dynamic inputs.
-  de: Dieser Skill kann Daten abrufen und Aktionen im MSFS2020-Simulator basierend auf dynamischen Eingaben ausführen.
+  en: This skill can retrieve data and perform actions in the MSFS2020/2024 simulator based on dynamic inputs.
+  de: Dieser Skill kann Daten abrufen und Aktionen im MSFS2020/2024-Simulator basierend auf dynamischen Eingaben ausführen.
 custom_properties:
   - hint: Whether to try to autostart data monitoring mode (tour guide mode), which automatically monitors for latitude, longitude and altitude. This can also be toggled with a voice command to start or end data monitoring mode.
     id: autostart_data_monitoring_loop_mode

--- a/skills/msfs2020_control/main.py
+++ b/skills/msfs2020_control/main.py
@@ -1,6 +1,8 @@
+import os
 import time
 import random
 import requests
+import sys
 from typing import TYPE_CHECKING
 from SimConnect import *
 from api.interface import (
@@ -11,6 +13,13 @@ from api.interface import (
 from api.enums import LogType
 from services.benchmark import Benchmark
 from skills.skill_base import Skill, tool
+
+
+# add skill to sys path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Import msfs2020 command processer helper
+from skills.msfs2020_control.command_matcher.command_matcher import CommandMatcher
 
 if TYPE_CHECKING:
     from wingmen.open_ai_wingman import OpenAiWingman
@@ -28,6 +37,7 @@ class Msfs2020Control(Skill):
         self.aq = None  # Same
         self.ae = None  # Same
         self.data_monitoring_loop_running = False
+        self.command_matcher = CommandMatcher()
 
     async def validate(self) -> list[WingmanInitializationError]:
         errors = await super().validate()
@@ -78,7 +88,27 @@ class Msfs2020Control(Skill):
         )
 
     @tool(
-        description="Retrieve data from MSFS2020 via SimConnect. Examples: PLANE_ALTITUDE, AIRSPEED_INDICATED, FUEL_TOTAL_QUANTITY, GEAR_HANDLE_POSITION. Use :index suffix for multi-engine (e.g., GENERAL_ENG_RPM:1)."
+        description="Retrieve the list of potential matching SimConnect commands (events) or data points (SimVars) to accomplish the user's intent."
+    )
+    async def get_potential_matching_commands(self, user_intent: str) -> str:
+        """
+        Retrieve the list of potential matching SimConnect commands (events) or data points (SimVars) to accomplish the user's intent. For use in get_data_from_sim and set_data_or_perform_action_in_sim.
+        Automatically use if there is a problem fetching data or accomplishing an action in the Sim to ensure the proper Event or SimVar is used.
+        Args:
+            user_intent: The user's intent expressed as a brief string, e.g., "set the heading to 270 degrees", "turn on autopilot", "set full throttle".
+        """
+        
+        matches = self.command_matcher.find_matches(user_intent)
+        matches_string = self.command_matcher.matches_as_string(matches)
+        if self.settings.debug_mode:
+            await self.printr.print_async(
+                f"Found potential matching commands for intent {user_intent}: {matches_string}",
+                color=LogType.INFO,
+            )
+        return matches_string
+
+    @tool(
+        description="Retrieve data from MSFS2020 via SimConnect SimVars. Examples: PLANE_ALTITUDE, AIRSPEED_INDICATED, FUEL_TOTAL_QUANTITY, GEAR_HANDLE_POSITION. Use :index suffix for multi-engine (e.g., GENERAL_ENG_RPM:1)."
     )
     async def get_data_from_sim(self, data_point: str) -> str:
         """
@@ -87,11 +117,17 @@ class Msfs2020Control(Skill):
         Args:
             data_point: The data point to retrieve, such as 'PLANE_ALTITUDE', 'PLANE_HEADING_DEGREES_TRUE'.
         """
+        
         value = self.aq.get(data_point)
+        if self.settings.debug_mode:
+            await self.printr.print_async(
+                f"Retrieving data point from sim: {data_point}; value returned: {value}",
+                color=LogType.INFO,
+            )
         return f"{data_point} value is: {value}"
 
     @tool(
-        description="Control MSFS2020 aircraft via SimConnect. Examples: THROTTLE_FULL, FLAPS_UP, GEAR_TOGGLE, AP_MASTER, TOGGLE_BEACON_LIGHTS. Use TOGGLE_ prefix for switches, _INCR/_DECR for adjustments. Pass argument for SET commands (0-16383)."
+        description="Control MSFS2020 aircraft via SimConnect Events. Examples: THROTTLE_FULL, FLAPS_UP, GEAR_TOGGLE, AP_MASTER, TOGGLE_BEACON_LIGHTS. Use TOGGLE_ prefix for switches, _INCR/_DECR for adjustments. Pass argument for SET commands (0-16383)."
     )
     async def set_data_or_perform_action_in_sim(
         self, action: str, argument: float = None
@@ -103,6 +139,11 @@ class Msfs2020Control(Skill):
             action: The action to perform or data point to set, such as 'TOGGLE_MASTER_BATTERY', 'THROTTLE_SET'.
             argument: The argument to pass for the action, if any.
         """
+        if self.settings.debug_mode:
+            await self.printr.print_async(
+                f"Attempting to perform action/set data in sim: {action} with argument: {argument}",
+                color=LogType.INFO,
+            )
         try:
             if argument is not None:
                 self.aq.set(action, argument)


### PR DESCRIPTION
-add new tool for finding possible msfs simvars or actions when llm guess fails to drastically increase effectiveness

-limit recommended commands to 15 to limit context bloat

-add more debug statements