### PR TITLE
Refactor joystick management to improve task handling and cleanup

### DIFF
--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -203,10 +203,6 @@ class CommandHandler:
 
         await self.handle_stop_recording(stop_command, None)
 
-        # Always quit pygame to ensure clean state - refresh_input_hooks will restart it if needed
-        if pygame.get_init():
-            pygame.quit()
-
         # Restart joystick thread if there are configured joystick buttons
         await self.core.refresh_input_hooks()
 

--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -59,8 +59,12 @@ class CommandHandler:
                     RecordMouseActionsCommand(**command), websocket
                 )
             elif command_name == "record_joystick_actions":
-                await self.handle_record_joystick_actions(
-                    RecordJoystickActionsCommand(**command), websocket
+                # Run as background task so the websocket loop stays responsive
+                # and can still process stop_recording commands.
+                asyncio.ensure_future(
+                    self.handle_record_joystick_actions(
+                        RecordJoystickActionsCommand(**command), websocket
+                    )
                 )
             elif command_name == "stop_recording":
                 await self.handle_stop_recording(

--- a/services/command_handler.py
+++ b/services/command_handler.py
@@ -1,8 +1,6 @@
 import json
 import asyncio
-import threading
 from fastapi import WebSocket
-import pygame
 import keyboard.keyboard as keyboard
 from api.commands import (
     ActionsRecordedCommand,
@@ -61,21 +59,9 @@ class CommandHandler:
                     RecordMouseActionsCommand(**command), websocket
                 )
             elif command_name == "record_joystick_actions":
-
-                def run_async_joystick_recording():
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                    try:
-                        loop.run_until_complete(
-                            self.handle_record_joystick_actions(
-                                RecordJoystickActionsCommand(**command), websocket
-                            )
-                        )
-                    finally:
-                        loop.close()
-
-                play_thread = threading.Thread(target=run_async_joystick_recording)
-                play_thread.start()
+                await self.handle_record_joystick_actions(
+                    RecordJoystickActionsCommand(**command), websocket
+                )
             elif command_name == "stop_recording":
                 await self.handle_stop_recording(
                     StopRecordingCommand(**command), websocket
@@ -167,44 +153,17 @@ class CommandHandler:
             server_only=True,
         )
 
-        # Stop the joystick thread in wingman_core to prevent event conflicts
-        # Both loops would otherwise compete for pygame events
-        await self.core._stop_joystick_thread()
-
         self.recorded_keys = []
-        pygame.init()
-        joysticks = [
-            pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
-        ]
-
-        for joystick in joysticks:
-            joystick.init()
-
         self.is_joystick_recording = True
-        while self.is_joystick_recording and pygame.get_init():
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    self.is_joystick_recording = False
-                elif event.type == pygame.JOYBUTTONUP:
-                    # Get guid of joystick with instance id
-                    joystick_origin = pygame.joystick.Joystick(event.joy)
-                    self.recorded_keys.append(
-                        {
-                            "button": event.button,
-                            "guid": joystick_origin.get_guid(),
-                            "name": joystick_origin.get_name(),
-                        }
-                    )
-                    self.is_joystick_recording = False
+        result = await self.core.record_joystick_action()
+        if result and self.is_joystick_recording:
+            self.recorded_keys.append(result)
 
         stop_command = StopRecordingCommand(
             command="stop_recording", recording_device=RecordingDevice.JOYSTICK
         )
 
         await self.handle_stop_recording(stop_command, None)
-
-        # Restart joystick thread if there are configured joystick buttons
-        await self.core.refresh_input_hooks()
 
     async def handle_record_keyboard_actions(
         self, command: RecordKeyboardActionsCommand, websocket: WebSocket
@@ -264,6 +223,7 @@ class CommandHandler:
             self.keyboard_hook_callback = None
         if command.recording_device == RecordingDevice.JOYSTICK:
             self.is_joystick_recording = False
+            self.core.cancel_joystick_recording()
         if command.recording_device == RecordingDevice.MOUSE:
             mouse.unhook(self.on_mouse)
 

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -594,62 +594,57 @@ class WingmanCore(WebSocketUser):
         return is_any_wingman_joystick_configured or is_cancel_tts_joystick_configured
 
     async def start_joysticks(self, config: Config):
-        try:
-            pygame.init()
-            # Get all joystick configs
-            joystick_configs: list[CommandJoystickConfig] = [
-                config.wingmen[wingman].record_joystick_button
-                for wingman in config.wingmen
-                if config.wingmen[wingman].record_joystick_button
-            ]
+        pygame.init()
+        # Get all joystick configs
+        joystick_configs: list[CommandJoystickConfig] = [
+            config.wingmen[wingman].record_joystick_button
+            for wingman in config.wingmen
+            if config.wingmen[wingman].record_joystick_button
+        ]
 
-            cancel_tts_joystick_button = getattr(
-                self.settings_service.settings, "cancel_tts_joystick_button", None
-            )
-            if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
-                joystick_configs.append(cancel_tts_joystick_button)
+        cancel_tts_joystick_button = getattr(
+            self.settings_service.settings, "cancel_tts_joystick_button", None
+        )
+        if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
+            joystick_configs.append(cancel_tts_joystick_button)
 
-            joysticks = [
-                pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
-            ]
-            for joystick in joysticks:
-                if any(
-                    joystick.get_guid() == joystick_config.guid
-                    for joystick_config in joystick_configs
-                    if joystick_config is not None and joystick_config.guid is not None
-                ):
-                    joystick.init()
+        joysticks = [
+            pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
+        ]
+        for joystick in joysticks:
+            if any(
+                joystick.get_guid() == joystick_config.guid
+                for joystick_config in joystick_configs
+                if joystick_config is not None and joystick_config.guid is not None
+            ):
+                joystick.init()
 
-            running = True
-            while running and pygame.joystick.get_init():
-                for event in pygame.event.get():
-                    if event.type == pygame.QUIT:
-                        running = False
-                    elif event.type == pygame.JOYBUTTONDOWN:
-                        joystick_origin = pygame.joystick.Joystick(event.joy)
-                        for joystick_config in joystick_configs:
-                            if joystick_origin.get_guid() == joystick_config.guid:
-                                self.on_press(
-                                    joystick_config=CommandJoystickConfig(
-                                        guid=joystick_config.guid, button=event.button
-                                    )
+        running = True
+        while running and pygame.joystick.get_init():
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                elif event.type == pygame.JOYBUTTONDOWN:
+                    joystick_origin = pygame.joystick.Joystick(event.joy)
+                    for joystick_config in joystick_configs:
+                        if joystick_origin.get_guid() == joystick_config.guid:
+                            self.on_press(
+                                joystick_config=CommandJoystickConfig(
+                                    guid=joystick_config.guid, button=event.button
                                 )
-                    elif event.type == pygame.JOYBUTTONUP:
-                        joystick_origin = pygame.joystick.Joystick(event.joy)
-                        for joystick_config in joystick_configs:
-                            if joystick_origin.get_guid() == joystick_config.guid:
-                                self.on_release(
-                                    joystick_config=CommandJoystickConfig(
-                                        guid=joystick_config.guid, button=event.button
-                                    )
+                            )
+                elif event.type == pygame.JOYBUTTONUP:
+                    joystick_origin = pygame.joystick.Joystick(event.joy)
+                    for joystick_config in joystick_configs:
+                        if joystick_origin.get_guid() == joystick_config.guid:
+                            self.on_release(
+                                joystick_config=CommandJoystickConfig(
+                                    guid=joystick_config.guid, button=event.button
                                 )
+                            )
 
-                # Add a small sleep to prevent the loop from consuming too much CPU
-                await asyncio.sleep(0.01)
-        finally:
-            # Always clean up pygame so the next init_joystick call can reinitialize
-            if pygame.get_init():
-                pygame.quit()
+            # Add a small sleep to prevent the loop from consuming too much CPU
+            await asyncio.sleep(0.01)
 
     async def init_joystick(self, config: Config):
         # Stop any existing joystick thread first to prevent thread accumulation
@@ -665,12 +660,16 @@ class WingmanCore(WebSocketUser):
                 # Run the event loop forever instead of running until complete
                 loop.run_forever()
             finally:
-                # Cancel all pending tasks before closing so pygame cleanup runs
-                pending = asyncio.all_tasks()
-                for task in pending:
+                # Ensure the task is cancelled and awaited before closing the loop.
+                # asyncio.all_tasks() raises RuntimeError when no loop is running
+                # (Python 3.10+), so we use the task reference directly instead.
+                task = self._joystick_task
+                if task and not task.done():
                     task.cancel()
-                if pending:
-                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                    try:
+                        loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+                    except Exception:
+                        pass
                 loop.close()
 
         self._joystick_thread = threading.Thread(target=run_async_process, daemon=True)
@@ -701,8 +700,6 @@ class WingmanCore(WebSocketUser):
                     server_only=True,
                 )
 
-        # Only clear references if the joystick thread has stopped.
-        # pygame.quit() is called by the task's finally block in start_joysticks
         if stopped_cleanly:
             self._joystick_thread = None
             self._joystick_loop = None

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -666,7 +666,7 @@ class WingmanCore(WebSocketUser):
                 loop.run_forever()
             finally:
                 # Cancel all pending tasks before closing so pygame cleanup runs
-                pending = asyncio.all_tasks(loop)
+                pending = asyncio.all_tasks()
                 for task in pending:
                     task.cancel()
                 if pending:

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -665,6 +665,12 @@ class WingmanCore(WebSocketUser):
                 # Run the event loop forever instead of running until complete
                 loop.run_forever()
             finally:
+                # Cancel all pending tasks before closing so pygame cleanup runs
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
                 loop.close()
 
         self._joystick_thread = threading.Thread(target=run_async_process, daemon=True)
@@ -673,12 +679,11 @@ class WingmanCore(WebSocketUser):
 
     async def _stop_joystick_thread(self):
         """Stop the joystick event loop and thread."""
-        # Cancel the task via the joystick loop (cross-loop: can't await a task from another loop)
-        # The task's finally block will call pygame.quit() to clean up DirectInput handles
-        if self._joystick_task and not self._joystick_task.done():
-            self._joystick_task.cancel()
-
         if self._joystick_loop and self._joystick_loop.is_running():
+            # Cancel the task thread-safely on the joystick loop
+            if self._joystick_task and not self._joystick_task.done():
+                self._joystick_loop.call_soon_threadsafe(self._joystick_task.cancel)
+
             # Schedule the loop to stop from another thread
             try:
                 self._joystick_loop.call_soon_threadsafe(self._joystick_loop.stop)
@@ -687,6 +692,12 @@ class WingmanCore(WebSocketUser):
 
         if self._joystick_thread and self._joystick_thread.is_alive():
             await asyncio.to_thread(self._joystick_thread.join, 1.0)
+            if self._joystick_thread.is_alive():
+                self.printr.print(
+                    "Warning: Joystick thread did not stop within timeout and may still be running.",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
 
         # pygame.quit() is called by the task's finally block in start_joysticks
         self._joystick_thread = None

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -381,6 +381,7 @@ class WingmanCore(WebSocketUser):
         # Joystick thread management
         self._joystick_thread: Optional[threading.Thread] = None
         self._joystick_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._joystick_task: Optional[asyncio.Task] = None
         self._mouse_hook_registered: bool = False
 
         self.settings_service = SettingsService(
@@ -593,57 +594,62 @@ class WingmanCore(WebSocketUser):
         return is_any_wingman_joystick_configured or is_cancel_tts_joystick_configured
 
     async def start_joysticks(self, config: Config):
-        pygame.init()
-        # Get all joystick configs
-        joystick_configs: list[CommandJoystickConfig] = [
-            config.wingmen[wingman].record_joystick_button
-            for wingman in config.wingmen
-            if config.wingmen[wingman].record_joystick_button
-        ]
+        try:
+            pygame.init()
+            # Get all joystick configs
+            joystick_configs: list[CommandJoystickConfig] = [
+                config.wingmen[wingman].record_joystick_button
+                for wingman in config.wingmen
+                if config.wingmen[wingman].record_joystick_button
+            ]
 
-        cancel_tts_joystick_button = getattr(
-            self.settings_service.settings, "cancel_tts_joystick_button", None
-        )
-        if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
-            joystick_configs.append(cancel_tts_joystick_button)
+            cancel_tts_joystick_button = getattr(
+                self.settings_service.settings, "cancel_tts_joystick_button", None
+            )
+            if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
+                joystick_configs.append(cancel_tts_joystick_button)
 
-        joysticks = [
-            pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
-        ]
-        for joystick in joysticks:
-            if any(
-                joystick.get_guid() == joystick_config.guid
-                for joystick_config in joystick_configs
-                if joystick_config is not None and joystick_config.guid is not None
-            ):
-                joystick.init()
+            joysticks = [
+                pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
+            ]
+            for joystick in joysticks:
+                if any(
+                    joystick.get_guid() == joystick_config.guid
+                    for joystick_config in joystick_configs
+                    if joystick_config is not None and joystick_config.guid is not None
+                ):
+                    joystick.init()
 
-        running = True
-        while running and pygame.joystick.get_init():
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    running = False
-                elif event.type == pygame.JOYBUTTONDOWN:
-                    joystick_origin = pygame.joystick.Joystick(event.joy)
-                    for joystick_config in joystick_configs:
-                        if joystick_origin.get_guid() == joystick_config.guid:
-                            self.on_press(
-                                joystick_config=CommandJoystickConfig(
-                                    guid=joystick_config.guid, button=event.button
+            running = True
+            while running and pygame.joystick.get_init():
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        running = False
+                    elif event.type == pygame.JOYBUTTONDOWN:
+                        joystick_origin = pygame.joystick.Joystick(event.joy)
+                        for joystick_config in joystick_configs:
+                            if joystick_origin.get_guid() == joystick_config.guid:
+                                self.on_press(
+                                    joystick_config=CommandJoystickConfig(
+                                        guid=joystick_config.guid, button=event.button
+                                    )
                                 )
-                            )
-                elif event.type == pygame.JOYBUTTONUP:
-                    joystick_origin = pygame.joystick.Joystick(event.joy)
-                    for joystick_config in joystick_configs:
-                        if joystick_origin.get_guid() == joystick_config.guid:
-                            self.on_release(
-                                joystick_config=CommandJoystickConfig(
-                                    guid=joystick_config.guid, button=event.button
+                    elif event.type == pygame.JOYBUTTONUP:
+                        joystick_origin = pygame.joystick.Joystick(event.joy)
+                        for joystick_config in joystick_configs:
+                            if joystick_origin.get_guid() == joystick_config.guid:
+                                self.on_release(
+                                    joystick_config=CommandJoystickConfig(
+                                        guid=joystick_config.guid, button=event.button
+                                    )
                                 )
-                            )
 
-            # Add a small sleep to prevent the loop from consuming too much CPU
-            await asyncio.sleep(0.01)
+                # Add a small sleep to prevent the loop from consuming too much CPU
+                await asyncio.sleep(0.01)
+        finally:
+            # Always clean up pygame so the next init_joystick call can reinitialize
+            if pygame.get_init():
+                pygame.quit()
 
     async def init_joystick(self, config: Config):
         # Stop any existing joystick thread first to prevent thread accumulation
@@ -655,7 +661,7 @@ class WingmanCore(WebSocketUser):
             self._joystick_loop = loop  # Store reference for cleanup
             try:
                 # Create a task for start_joysticks instead of running it directly
-                loop.create_task(self.start_joysticks(config))
+                self._joystick_task = loop.create_task(self.start_joysticks(config))
                 # Run the event loop forever instead of running until complete
                 loop.run_forever()
             finally:
@@ -667,6 +673,11 @@ class WingmanCore(WebSocketUser):
 
     async def _stop_joystick_thread(self):
         """Stop the joystick event loop and thread."""
+        # Cancel the task via the joystick loop (cross-loop: can't await a task from another loop)
+        # The task's finally block will call pygame.quit() to clean up DirectInput handles
+        if self._joystick_task and not self._joystick_task.done():
+            self._joystick_task.cancel()
+
         if self._joystick_loop and self._joystick_loop.is_running():
             # Schedule the loop to stop from another thread
             try:
@@ -676,22 +687,11 @@ class WingmanCore(WebSocketUser):
 
         if self._joystick_thread and self._joystick_thread.is_alive():
             await asyncio.to_thread(self._joystick_thread.join, 1.0)
-            if self._joystick_thread.is_alive():
-                self.printr.print(
-                    "WARNING: Joystick thread did not stop in time",
-                    color=LogType.WARNING,
-                    server_only=True,
-                )
 
-        # Clean up pygame to allow fresh initialization later
-        if pygame.get_init():
-            try:
-                pygame.quit()
-            except Exception:
-                pass  # May fail if pygame is in an inconsistent state
-
+        # pygame.quit() is called by the task's finally block in start_joysticks
         self._joystick_thread = None
         self._joystick_loop = None
+        self._joystick_task = None
 
     async def refresh_input_hooks(self):
         """Refresh mouse and joystick hooks based on current wingman configurations.

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -679,6 +679,7 @@ class WingmanCore(WebSocketUser):
 
     async def _stop_joystick_thread(self):
         """Stop the joystick event loop and thread."""
+        stopped_cleanly = True
         if self._joystick_loop and self._joystick_loop.is_running():
             # Cancel the task thread-safely on the joystick loop
             if self._joystick_task and not self._joystick_task.done():
@@ -693,16 +694,19 @@ class WingmanCore(WebSocketUser):
         if self._joystick_thread and self._joystick_thread.is_alive():
             await asyncio.to_thread(self._joystick_thread.join, 1.0)
             if self._joystick_thread.is_alive():
+                stopped_cleanly = False
                 self.printr.print(
                     "Warning: Joystick thread did not stop within timeout and may still be running.",
                     color=LogType.WARNING,
                     server_only=True,
                 )
 
+        # Only clear references if the joystick thread has stopped.
         # pygame.quit() is called by the task's finally block in start_joysticks
-        self._joystick_thread = None
-        self._joystick_loop = None
-        self._joystick_task = None
+        if stopped_cleanly:
+            self._joystick_thread = None
+            self._joystick_loop = None
+            self._joystick_task = None
 
     async def refresh_input_hooks(self):
         """Refresh mouse and joystick hooks based on current wingman configurations.

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -382,7 +382,11 @@ class WingmanCore(WebSocketUser):
         self._joystick_thread: Optional[threading.Thread] = None
         self._joystick_loop: Optional[asyncio.AbstractEventLoop] = None
         self._joystick_task: Optional[asyncio.Task] = None
+        self._joystick_configs: list = []
         self._mouse_hook_registered: bool = False
+        self._joystick_recording_active: bool = False
+        self._joystick_recording_event: Optional[threading.Event] = None
+        self._joystick_recording_result: Optional[dict] = None
 
         self.settings_service = SettingsService(
             config_manager=config_manager, config_service=self.config_service
@@ -593,31 +597,15 @@ class WingmanCore(WebSocketUser):
 
         return is_any_wingman_joystick_configured or is_cancel_tts_joystick_configured
 
-    async def start_joysticks(self, config: Config):
+    async def start_joysticks(self):
         pygame.init()
-        # Get all joystick configs
-        joystick_configs: list[CommandJoystickConfig] = [
-            config.wingmen[wingman].record_joystick_button
-            for wingman in config.wingmen
-            if config.wingmen[wingman].record_joystick_button
-        ]
-
-        cancel_tts_joystick_button = getattr(
-            self.settings_service.settings, "cancel_tts_joystick_button", None
-        )
-        if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
-            joystick_configs.append(cancel_tts_joystick_button)
-
+        # Initialize ALL joysticks upfront so they generate events for both
+        # normal operation and recording mode.
         joysticks = [
             pygame.joystick.Joystick(x) for x in range(pygame.joystick.get_count())
         ]
         for joystick in joysticks:
-            if any(
-                joystick.get_guid() == joystick_config.guid
-                for joystick_config in joystick_configs
-                if joystick_config is not None and joystick_config.guid is not None
-            ):
-                joystick.init()
+            joystick.init()
 
         running = True
         while running and pygame.joystick.get_init():
@@ -626,29 +614,64 @@ class WingmanCore(WebSocketUser):
                     running = False
                 elif event.type == pygame.JOYBUTTONDOWN:
                     joystick_origin = pygame.joystick.Joystick(event.joy)
-                    for joystick_config in joystick_configs:
-                        if joystick_origin.get_guid() == joystick_config.guid:
-                            self.on_press(
-                                joystick_config=CommandJoystickConfig(
-                                    guid=joystick_config.guid, button=event.button
+                    # In recording mode, skip normal press handling
+                    if not self._joystick_recording_active:
+                        for joystick_config in self._joystick_configs:
+                            if joystick_origin.get_guid() == joystick_config.guid:
+                                self.on_press(
+                                    joystick_config=CommandJoystickConfig(
+                                        guid=joystick_config.guid, button=event.button
+                                    )
                                 )
-                            )
                 elif event.type == pygame.JOYBUTTONUP:
                     joystick_origin = pygame.joystick.Joystick(event.joy)
-                    for joystick_config in joystick_configs:
-                        if joystick_origin.get_guid() == joystick_config.guid:
-                            self.on_release(
-                                joystick_config=CommandJoystickConfig(
-                                    guid=joystick_config.guid, button=event.button
+                    # In recording mode, capture the button press and signal the caller
+                    if self._joystick_recording_active and self._joystick_recording_event:
+                        self._joystick_recording_result = {
+                            "button": event.button,
+                            "guid": joystick_origin.get_guid(),
+                            "name": joystick_origin.get_name(),
+                        }
+                        self._joystick_recording_event.set()
+                    else:
+                        for joystick_config in self._joystick_configs:
+                            if joystick_origin.get_guid() == joystick_config.guid:
+                                self.on_release(
+                                    joystick_config=CommandJoystickConfig(
+                                        guid=joystick_config.guid, button=event.button
+                                    )
                                 )
-                            )
 
             # Add a small sleep to prevent the loop from consuming too much CPU
             await asyncio.sleep(0.01)
 
+    def _build_joystick_configs(self, config: Config) -> list:
+        """Build the list of joystick configs from wingman and settings config."""
+        joystick_configs: list[CommandJoystickConfig] = [
+            config.wingmen[wingman].record_joystick_button
+            for wingman in config.wingmen
+            if config.wingmen[wingman].record_joystick_button
+        ]
+        cancel_tts_joystick_button = getattr(
+            self.settings_service.settings, "cancel_tts_joystick_button", None
+        )
+        if cancel_tts_joystick_button is not None and cancel_tts_joystick_button.guid:
+            joystick_configs.append(cancel_tts_joystick_button)
+        return joystick_configs
+
     async def init_joystick(self, config: Config):
-        # Stop any existing joystick thread first to prevent thread accumulation
-        await self._stop_joystick_thread()
+        # Update the configs that the joystick loop reads dynamically
+        self._joystick_configs = self._build_joystick_configs(config)
+
+        # If the thread is already running, no need to restart it.
+        # The loop reads _joystick_configs on every iteration.
+        if self._joystick_thread and self._joystick_thread.is_alive():
+            return
+
+        # Clear stale references from a previously dead thread
+        self._joystick_thread = None
+        self._joystick_loop = None
+        self._joystick_task = None
 
         def run_async_process():
             loop = asyncio.new_event_loop()
@@ -656,7 +679,7 @@ class WingmanCore(WebSocketUser):
             self._joystick_loop = loop  # Store reference for cleanup
             try:
                 # Create a task for start_joysticks instead of running it directly
-                self._joystick_task = loop.create_task(self.start_joysticks(config))
+                self._joystick_task = loop.create_task(self.start_joysticks())
                 # Run the event loop forever instead of running until complete
                 loop.run_forever()
             finally:
@@ -676,34 +699,41 @@ class WingmanCore(WebSocketUser):
         self._joystick_thread.name = "JoystickEventLoop"
         self._joystick_thread.start()
 
-    async def _stop_joystick_thread(self):
-        """Stop the joystick event loop and thread."""
-        stopped_cleanly = True
-        if self._joystick_loop and self._joystick_loop.is_running():
-            # Cancel the task thread-safely on the joystick loop
-            if self._joystick_task and not self._joystick_task.done():
-                self._joystick_loop.call_soon_threadsafe(self._joystick_task.cancel)
+    async def record_joystick_action(self) -> dict:
+        """Record a single joystick button press using the existing joystick event loop.
 
-            # Schedule the loop to stop from another thread
-            try:
-                self._joystick_loop.call_soon_threadsafe(self._joystick_loop.stop)
-            except RuntimeError:
-                pass  # Loop may already be closed
+        If no joystick thread is running, starts one for recording.
+        Returns a dict with 'button', 'guid', and 'name' keys, or None if cancelled.
+        """
+        if not self._joystick_thread or not self._joystick_thread.is_alive():
+            config = (
+                self.tower.config
+                if self.tower
+                else self.config_service.current_config
+            )
+            await self.init_joystick(config)
 
-        if self._joystick_thread and self._joystick_thread.is_alive():
-            await asyncio.to_thread(self._joystick_thread.join, 1.0)
-            if self._joystick_thread.is_alive():
-                stopped_cleanly = False
-                self.printr.print(
-                    "Warning: Joystick thread did not stop within timeout and may still be running.",
-                    color=LogType.WARNING,
-                    server_only=True,
-                )
+        # Use a threading.Event to synchronize across event loops instead of
+        # asyncio futures, which cannot be awaited from a different loop.
+        self._joystick_recording_event = threading.Event()
+        self._joystick_recording_result = None
+        self._joystick_recording_active = True
 
-        if stopped_cleanly:
-            self._joystick_thread = None
-            self._joystick_loop = None
-            self._joystick_task = None
+        try:
+            # Poll the threading event from the caller's async loop
+            while not self._joystick_recording_event.is_set():
+                await asyncio.sleep(0.01)
+            return self._joystick_recording_result
+        finally:
+            self._joystick_recording_active = False
+            self._joystick_recording_event = None
+            self._joystick_recording_result = None
+
+    def cancel_joystick_recording(self):
+        """Cancel an in-progress joystick recording."""
+        self._joystick_recording_active = False
+        if self._joystick_recording_event:
+            self._joystick_recording_event.set()
 
     async def refresh_input_hooks(self):
         """Refresh mouse and joystick hooks based on current wingman configurations.
@@ -749,9 +779,8 @@ class WingmanCore(WebSocketUser):
         )
 
         if needs_joystick:
-            # Restart joystick thread to pick up new button configurations
-            # The joystick loop uses a static list of configs, so we must restart it
-            # Build current config from tower wingmen since tower.config may be stale
+            # Update joystick configs dynamically — no thread restart needed.
+            # The joystick loop reads _joystick_configs on every iteration.
             current_wingmen = {
                 wingman.name: wingman.config for wingman in self.tower.wingmen
             }
@@ -765,8 +794,9 @@ class WingmanCore(WebSocketUser):
                 server_only=True,
             )
         elif joystick_running and not needs_joystick:
-            # No joystick needed anymore, stop the thread
-            await self._stop_joystick_thread()
+            # No joystick needed anymore — clear configs so the loop idles,
+            # but keep the thread alive for future recordings.
+            self._joystick_configs = []
 
     async def on_wingman_config_saved(self, wingman_config):
         """Called when a wingman config is saved. Refreshes input hooks if needed."""
@@ -832,8 +862,10 @@ class WingmanCore(WebSocketUser):
             self.tower = None
             self.config_service.set_tower(None)
 
-            # Stop joystick thread to prevent thread accumulation on reload
-            await self._stop_joystick_thread()
+            # Clear joystick configs so the loop idles, but keep the thread
+            # alive. Restarting it on a new thread breaks pygame's DirectInput
+            # handles which are bound to the thread that created them.
+            self._joystick_configs = []
 
             # Unhook mouse to prevent duplicate hooks
             try:

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -642,8 +642,11 @@ class WingmanCore(WebSocketUser):
                                     )
                                 )
 
-            # Add a small sleep to prevent the loop from consuming too much CPU
-            await asyncio.sleep(0.01)
+            # Sleep longer when idle (no configs and not recording) to reduce CPU usage
+            if not self._joystick_configs and not self._joystick_recording_active:
+                await asyncio.sleep(0.1)
+            else:
+                await asyncio.sleep(0.01)
 
     def _build_joystick_configs(self, config: Config) -> list:
         """Build the list of joystick configs from wingman and settings config."""
@@ -678,9 +681,20 @@ class WingmanCore(WebSocketUser):
             asyncio.set_event_loop(loop)
             self._joystick_loop = loop  # Store reference for cleanup
             try:
-                # Create a task for start_joysticks instead of running it directly
                 self._joystick_task = loop.create_task(self.start_joysticks())
-                # Run the event loop forever instead of running until complete
+
+                # Stop the loop if the task finishes unexpectedly (e.g. exception)
+                # so the finally block runs and the thread exits cleanly.
+                def on_task_done(task):
+                    if task.exception():
+                        self.printr.print(
+                            f"Joystick event loop error: {task.exception()}",
+                            color=LogType.WARNING,
+                            server_only=True,
+                        )
+                    loop.call_soon_threadsafe(loop.stop)
+
+                self._joystick_task.add_done_callback(on_task_done)
                 loop.run_forever()
             finally:
                 # Ensure the task is cancelled and awaited before closing the loop.

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -699,7 +699,7 @@ class WingmanCore(WebSocketUser):
         self._joystick_thread.name = "JoystickEventLoop"
         self._joystick_thread.start()
 
-    async def record_joystick_action(self) -> dict:
+    async def record_joystick_action(self) -> dict|None:
         """Record a single joystick button press using the existing joystick event loop.
 
         If no joystick thread is running, starts one for recording.


### PR DESCRIPTION
This pull request refactors joystick recording and event handling to improve reliability, reduce threading complexity, and allow for more responsive and robust joystick input handling. The changes remove direct dependencies on `pygame` in the command handler, centralize joystick event management in `wingman_core.py`, and ensure that joystick configuration updates are handled dynamically without restarting threads.

**Joystick Event Handling and Recording Refactor:**

- Replaced the previous approach of starting a new thread per joystick recording session with a persistent joystick event loop running in its own thread, managed by `wingman_core.py`. Joystick recording now uses a synchronization event to capture button presses without interrupting the main event loop. [[1]](diffhunk://#diff-ac822e92ec7c6b009348607436e169f5d47d3d92e82700ed33a94d9b3b290b03L64-L78) [[2]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L637-R750) [[3]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L628-R619) [[4]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827R384-R389) F9ebd649L614R614)

- The command handler (`command_handler.py`) no longer directly imports or manages `pygame`, and instead delegates joystick recording to the core's new `record_joystick_action` method, simplifying the code and improving separation of concerns. [[1]](diffhunk://#diff-ac822e92ec7c6b009348607436e169f5d47d3d92e82700ed33a94d9b3b290b03L3-L5) [[2]](diffhunk://#diff-ac822e92ec7c6b009348607436e169f5d47d3d92e82700ed33a94d9b3b290b03L170-L212)

**Dynamic Joystick Configuration and Resource Management:**

- The joystick event loop now reads its configuration (`_joystick_configs`) dynamically on every iteration, allowing updates to take effect immediately without restarting the thread. This enables more responsive updates when joystick settings change. [[1]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L628-R619) [[2]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L740-R797) [[3]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L756-R813)

- When joystick input is no longer needed, the system clears the configuration list to idle the loop instead of stopping and restarting the thread, which avoids issues with `pygame`'s DirectInput handles and thread affinity. [[1]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L756-R813) [[2]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L823-R882)

**Recording Cancellation and Cleanup:**

- Added a `cancel_joystick_recording` method to allow in-progress joystick recordings to be cancelled cleanly, improving user experience and reliability. [[1]](diffhunk://#diff-ac822e92ec7c6b009348607436e169f5d47d3d92e82700ed33a94d9b3b290b03R230) [[2]](diffhunk://#diff-7835b6c2cc7fa94c5e9c7a3723a6a73e719ecbe85d6b9aece9a73f7de962c827L637-R750)

These changes together make joystick handling more robust, efficient, and maintainable, while reducing the risk of threading and resource management bugs.