### PR TITLE
Gemini latest support for instant tool calls

### DIFF
--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -1419,8 +1419,13 @@ class OpenAiWingman(Wingman):
                 self.config.features.conversation_provider
                 == ConversationProvider.GOOGLE
             ):
-                if self.config.google.conversation_model.startswith("gemini-3"):
-                    # gemini 3 needs a thought signature like this, but we cant fake it:
+                if (
+                    self.config.google.conversation_model.startswith("gemini-3")
+                    or self.config.google.conversation_model == "gemini-flash-latest"
+                    or self.config.google.conversation_model == "gemini-pro-latest"
+                    or self.config.google.conversation_model == "gemini-flash-lite-latest"
+                ):
+                    # gemini 3+ (latest = 3+) needs a thought signature like this, but we cant fake it:
                     # {
                     #     'model_extra': {
                     #         'extra_content': {


### PR DESCRIPTION
This pull request updates the logic for determining which Google Gemini models require a special "thought signature" in the `add_forced_assistant_command_calls` method. The check now includes additional Gemini models beyond just those starting with "gemini-3".

Model selection logic update:

* Expanded the conditional to include `gemini-flash-latest`, `gemini-pro-latest`, and `gemini-flash-lite-latest` models, in addition to models starting with `gemini-3`, when determining if a special "thought signature" is required for Google Gemini conversation models in `wingmen/open_ai_wingman.py`.