### PR TITLE
Fix hallucinated tool calls and reasoning for Google models

### DIFF
--- a/providers/google.py
+++ b/providers/google.py
@@ -72,13 +72,14 @@ class GoogleGenAI:
             # Flash and other non-Pro 2.5 variants allow disabling thinking.
             return {"reasoning_effort": "none"}
 
-        if "3.1" in normalized:
+        # Gemini 3 models
+        if "-3-" in normalized:
             if "pro" in normalized:
                 return {"reasoning_effort": "low"}
             return {"reasoning_effort": "minimal"}
 
-        # Gemini 3 models: minimal is not a valid value; use the lowest supported value.
-        if "-3-" in normalized:
+        # Gemini 3.1 models
+        if "3.1" in normalized:
             if "pro" in normalized:
                 return {"reasoning_effort": "low"}
             return {"reasoning_effort": "minimal"}

--- a/providers/google.py
+++ b/providers/google.py
@@ -72,9 +72,16 @@ class GoogleGenAI:
             # Flash and other non-Pro 2.5 variants allow disabling thinking.
             return {"reasoning_effort": "none"}
 
+        if "3.1" in normalized:
+            if "pro" in normalized:
+                return {"reasoning_effort": "low"}
+            return {"reasoning_effort": "minimal"}
+
         # Gemini 3 models: minimal is not a valid value; use the lowest supported value.
-        if re.search(r"(^|[^0-9])3([^0-9]|$)", normalized):
-            return {"reasoning_effort": "low"}
+        if "-3-" in normalized:
+            if "pro" in normalized:
+                return {"reasoning_effort": "low"}
+            return {"reasoning_effort": "minimal"}
 
         # Other Gemini aliases (e.g. gemini-flash-latest / gemini-pro-latest) may vary.
         # Don't send reasoning_effort unless we know it's supported.

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -1856,7 +1856,7 @@ class OpenAiWingman(Wingman):
         if content is None:
             response_message.content = ""
 
-        # remove hallucinated tools, if non were allowed
+        # remove hallucinated tools, if none were allowed
         if not allow_tool_calls:
             response_message.tool_calls = None
 

--- a/wingmen/open_ai_wingman.py
+++ b/wingmen/open_ai_wingman.py
@@ -1058,7 +1058,7 @@ class OpenAiWingman(Wingman):
             )
             return None, None, None, True
 
-        response_message, tool_calls = await self._process_completion(completion)
+        response_message, tool_calls = await self._process_completion(completion, instant_command_executed is False)
 
         # add message and dummy tool responses to conversation history
         is_waiting_response_needed, is_summarize_needed = await self._add_gpt_response(
@@ -1840,7 +1840,7 @@ class OpenAiWingman(Wingman):
 
         return completion
 
-    async def _process_completion(self, completion: ChatCompletion):
+    async def _process_completion(self, completion: ChatCompletion, allow_tool_calls: bool = True):
         """Processes the completion returned by the LLM call.
 
         Args:
@@ -1855,6 +1855,10 @@ class OpenAiWingman(Wingman):
         content = response_message.content
         if content is None:
             response_message.content = ""
+
+        # remove hallucinated tools, if non were allowed
+        if not allow_tool_calls:
+            response_message.tool_calls = None
 
         # temporary fix for tool calls that have a command name as function name
         if response_message.tool_calls:


### PR DESCRIPTION
This pull request introduces targeted improvements to how reasoning effort is determined for Gemini models in `google.py`, and refines the handling of tool calls in LLM completions within `open_ai_wingman.py`. The changes ensure that the correct reasoning effort is set for specific Gemini model variants and that tool calls are only included in responses when appropriate.

**Gemini model reasoning effort handling:**

* Updated `get_minimal_reasoning_by_model` in `google.py` to more precisely detect Gemini 3.1 and 3 model variants, assigning `"low"` or `"minimal"` reasoning effort depending on whether the model is a "pro" variant. This improves compatibility and accuracy when interacting with different Gemini models.

**Tool call handling in OpenAI Wingman:**

* Modified `_process_completion` in `open_ai_wingman.py` to accept a new `allow_tool_calls` parameter, controlling whether tool calls are included in the response. If not allowed, hallucinated tool calls are removed from the response. [[1]](diffhunk://#diff-ed52266b26698a5faa82734d566aa80aa927a7ceed409510c315c6d34d4d85eaL1843-R1843) [[2]](diffhunk://#diff-ed52266b26698a5faa82734d566aa80aa927a7ceed409510c315c6d34d4d85eaR1859-R1862)
* Updated `_get_response_for_transcript` to pass the correct value for `allow_tool_calls` to `_process_completion`, ensuring tool calls are only processed when appropriate.