### PR TITLE
Return False if hotkey codes list is empty

### DIFF
--- a/wingman_core.py
+++ b/wingman_core.py
@@ -1425,6 +1425,9 @@ class WingmanCore(WebSocketUser):
         if isinstance(hotkey, list):
             codes = hotkey
 
+        if not codes:
+            return False
+
         # check if all hotkey codes are in the key events code list
         is_pressed = all(code in self.key_events for code in codes)
 


### PR DESCRIPTION
Add check for empty hotkey codes list before processing.

## Linked Issue

No issue

## Summary

Fix `is_hotkey_pressed` to return `False` when the provided hotkey list is empty.

## Testing

With empty shutup key, the `is_hotkey_pressed` is constantly triggering during PTT action and therefore interrupting the mic recording leading to a broken PTT.

## Checklist

- [Nope] This PR is linked to a GitHub issue
- [Yupp] I have tested my changes locally
- [Nope, change proposed through web editor] I have rebased my branch onto `develop`
