### PR TITLE
potential fix for fasterwhisper build spec

### DIFF
--- a/WingmanAiCore.spec
+++ b/WingmanAiCore.spec
@@ -250,6 +250,15 @@ datas += onnx_asr_datas
 binaries += onnx_asr_binaries
 hiddenimports += onnx_asr_hidden
 
+# Collect all faster_whisper files (specifically assets like silero_vad_v6.onnx)
+try:
+    fw_datas, fw_binaries, fw_hidden = collect_all('faster_whisper')
+    datas += fw_datas
+    binaries += fw_binaries
+    hiddenimports += fw_hidden
+except Exception as e:
+    print(f"Warning: Could not collect faster_whisper: {e}")
+
 # ============================================================================
 # ANALYSIS
 # ============================================================================


### PR DESCRIPTION
## Linked Issue

None

## Summary

Added fasterwhisper specific files to build spec.

## Testing

Partially tested.
I was able to build the core exe with these changes and it produced the faster_whisper directory in `_internal` that was previously misisng.
But my build failed on other DLLs.
Therefore I put the created faster_whisper folder into the release `_internal` folder and it worked.
This leads me to think that this fix might work

## Checklist

- [ ] This PR is linked to a GitHub issue
- [x] I have tested my changes locally
- [x] I have rebased my branch onto `develop`
