### PR TITLE
Fix PocketTTS voice cloning on first start (R2-hosted weights) + harden model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ We would like to thank their creators for their great work and contributions to 
 - [packaging](https://github.com/pypa/packaging) - Apache/BSD, © Donald Stufft and individual contributors
 - [pedalboard](https://github.com/spotify/pedalboard) - GPL-3.0, © 2021-2023 Spotify AB
 - [pocket-tts](https://github.com/kyutai-labs/pocket-tts) - MIT
+- pocket-tts model weights - © Kyutai Labs, [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/), redistributed unmodified from [kyutai/pocket-tts](https://huggingface.co/kyutai/pocket-tts). Subject to Kyutai's acceptable-use terms: no voice cloning without explicit, lawful consent; no unlawful, harmful, deceptive or privacy-invasive use.
 - [platformdirs](https://github.com/platformdirs/platformdirs) - MIT, © 2010-202x plaformdirs developers
 - [pydantic](https://github.com/pydantic/pydantic) - MIT, © 2017 to present Pydantic Services Inc. and individual contributors
 - [pydirectinput-rgx](https://github.com/ReggX/pydirectinput_rgx) - MIT, © 2022 dev@reggx.eu, 2020 Ben Johnson

--- a/providers/pocket_tts.py
+++ b/providers/pocket_tts.py
@@ -19,6 +19,11 @@ from api.interface import (
     VoiceInfo,
 )
 from providers.interfaces import TtsInterface, tts_provider
+from providers.pocket_tts_r2 import (
+    build_r2_config,
+    prefetch_gated_weights,
+    use_r2_mirror,
+)
 from services.file import get_custom_voices_dir, get_pocket_tts_models_dir
 from services.audio_player import AudioPlayer
 from services.printr import Printr
@@ -243,9 +248,40 @@ class PocketTTS:
                 self.model = TTSModel.load_model(
                     config=model_path, quantize=quantize
                 )
+            elif use_r2_mirror():
+                # Redirect the gated voice-cloning weights to our R2 mirror so users
+                # without an HF token can clone voices (see providers/pocket_tts_r2.py).
+                config_path = build_r2_config(model_id, self.models_dir)
+                self.printr.print(
+                    f"Loading PocketTTS model: {model_id} from R2 mirror (quantize={quantize})...",
+                    color=LogType.INFO,
+                    server_only=True,
+                )
+                # Pre-populate pocket_tts's cache with retries + atomic writes so
+                # its own fragile download path (no timeout/retry/size check)
+                # never runs for the large cloning weights. On failure, warn and
+                # continue — the library falls back to the public non-cloning
+                # weights instead of silently breaking with no explanation.
+                try:
+                    prefetch_gated_weights(
+                        model_id,
+                        log=lambda msg: self.printr.print(
+                            msg, color=LogType.INFO, server_only=True
+                        ),
+                    )
+                except Exception as fetch_err:
+                    self.printr.toast_warning(
+                        "Could not download the PocketTTS voice-cloning weights. "
+                        "Voice cloning may be unavailable — check your internet "
+                        f"connection and restart Wingman AI.\nError: {fetch_err}"
+                    )
+                self.model = TTSModel.load_model(
+                    config=config_path,
+                    quantize=quantize,
+                )
             else:
                 self.printr.print(
-                    f"Loading PocketTTS model: {model_id} (quantize={quantize})...",
+                    f"Loading PocketTTS model: {model_id} from HuggingFace (quantize={quantize})...",
                     color=LogType.INFO,
                     server_only=True,
                 )

--- a/providers/pocket_tts_r2.py
+++ b/providers/pocket_tts_r2.py
@@ -1,0 +1,244 @@
+"""Redirect PocketTTS model downloads from HuggingFace to our Cloudflare R2 mirror.
+
+The upstream ``pocket_tts`` library resolves its weights from ``hf://`` URIs baked
+into the per-language YAML configs it ships (see ``pocket_tts/config/*.yaml``). The
+voice-cloning weights live in the *gated* ``kyutai/pocket-tts`` repo, which requires
+an HF account that accepted the terms plus a token - something our end users don't
+have. On first start the download therefore fails, the library silently falls back
+to the non-cloning weights, and any clone attempt raises ``VOICE_CLONING_UNSUPPORTED``.
+
+We mirror the required files (unmodified) to our own R2 bucket - permitted by the
+model's CC-BY-4.0 license - and rewrite the configs at load time so every ``hf://``
+URI points at ``release.wingman-ai.com`` instead. ``pocket_tts``'s own
+``download_if_necessary`` already understands plain ``https://`` URLs, so no library
+patching is needed.
+
+Both this module (runtime rewrite) and ``scripts/mirror_pocket_tts_r2.py`` (upload)
+derive R2 URLs through :func:`hf_uri_to_r2_url`, so the paths are guaranteed to match.
+"""
+
+import hashlib
+import os
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+import requests
+
+# Public base URL of the R2 ``wingman-releases`` bucket (custom domain), plus the
+# top-level ``models/`` prefix. This prefix is NOT touched by the release-cleanup
+# job in wingman-client, which only prunes ``vX.Y.Z/`` semver folders.
+POCKET_TTS_R2_BASE = "https://release.wingman-ai.com/models"
+
+# We only mirror files from the *gated* repo - that is the sole thing users can't
+# download without an HF token, and thus the entire cause of the bug. The tokenizer
+# and non-cloning weights live in a public repo and are fetched straight from HF (no
+# token needed), which also keeps our R2 storage/footprint to the minimum and leaves
+# a genuine cross-host fallback if R2 is ever unreachable.
+GATED_REPO_PREFIX = "hf://kyutai/pocket-tts/"
+
+# Escape hatch for developers: set to ``hf`` to bypass the R2 mirror and let the
+# library download straight from HuggingFace (requires a local HF token for the
+# gated cloning weights). Any other value (or unset) uses the R2 mirror.
+_SOURCE_ENV = "WINGMAN_POCKET_TTS_SOURCE"
+
+_HF_URI_RE = re.compile(r"hf://\S+")
+
+
+def use_r2_mirror() -> bool:
+    """Whether builtin models should load from the R2 mirror (default) or HF."""
+    return os.environ.get(_SOURCE_ENV, "").strip().lower() != "hf"
+
+
+def hf_uri_to_r2_url(hf_uri: str) -> str:
+    """Map a single ``hf://owner/repo/path/file.ext@revision`` URI to its R2 URL.
+
+    The revision is preserved as a path segment right before the filename so that a
+    future ``pocket_tts`` bump (new revisions) fails loudly with a 404 against the
+    stale mirror instead of silently serving weights that no longer match the config.
+
+    ``hf://kyutai/pocket-tts/languages/english_2026-04/model.safetensors@19f95fe``
+    -> ``<base>/kyutai/pocket-tts/languages/english_2026-04/19f95fe/model.safetensors``
+    """
+    if not hf_uri.startswith("hf://"):
+        return hf_uri
+    body = hf_uri[len("hf://") :]
+    revision = None
+    if "@" in body:
+        body, revision = body.rsplit("@", 1)
+    if revision:
+        head, _, filename = body.rpartition("/")
+        body = f"{head}/{revision}/{filename}" if head else f"{revision}/{filename}"
+    return f"{POCKET_TTS_R2_BASE.rstrip('/')}/{body}"
+
+
+def is_gated_uri(hf_uri: str) -> bool:
+    """Whether a URI points at the gated ``kyutai/pocket-tts`` repo.
+
+    The trailing slash is required to avoid matching the *public*
+    ``kyutai/pocket-tts-without-voice-cloning`` repo, which we deliberately leave on HF.
+    """
+    return hf_uri.startswith(GATED_REPO_PREFIX)
+
+
+def rewrite_config_text(text: str) -> str:
+    """Rewrite gated ``hf://`` URIs in a raw YAML config to their R2 equivalent.
+
+    Only URIs from the gated repo are redirected to R2; public URIs (tokenizer,
+    non-cloning weights) are left untouched so they keep downloading straight from HF.
+
+    Operates on the raw text (not a parsed tree) so comments and formatting are kept
+    verbatim. ``hf://`` URIs are unquoted YAML scalars with no whitespace, so the
+    ``\\S+`` match cleanly captures exactly one URI.
+    """
+
+    def _sub(m: "re.Match") -> str:
+        uri = m.group(0)
+        return hf_uri_to_r2_url(uri) if is_gated_uri(uri) else uri
+
+    return _HF_URI_RE.sub(_sub, text)
+
+
+def iter_gated_uris(text: str):
+    """Yield every gated ``hf://`` URI in a raw YAML config (used by the mirror)."""
+    return [u for u in _HF_URI_RE.findall(text) if is_gated_uri(u)]
+
+
+def library_config_path(model_id: str) -> Path:
+    """Absolute path to the ``pocket_tts`` library's bundled config for a language."""
+    from pocket_tts.utils.config import CONFIGS_DIR
+
+    return Path(CONFIGS_DIR) / f"{model_id}.yaml"
+
+
+def build_r2_config(model_id: str, cache_dir: str) -> str:
+    """Write an R2-rewritten copy of a builtin language config and return its path.
+
+    Args:
+        model_id: A builtin language id (e.g. ``english_2026-04``, ``german_24l``).
+        cache_dir: Directory to write the rewritten config into (created if needed).
+
+    Returns:
+        The absolute path to the rewritten YAML, ready to pass to
+        ``TTSModel.load_model(config=...)``.
+    """
+    src = library_config_path(model_id)
+    if not src.exists():
+        raise FileNotFoundError(f"No bundled pocket_tts config for '{model_id}' at {src}")
+
+    out_dir = Path(cache_dir) / ".r2-configs"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{model_id}.yaml"
+    # Atomic write: a settings-change reload (daemon thread) may race the initial
+    # deferred load; never let the library read a half-written config.
+    tmp_path = out_dir / f".{model_id}.yaml.{os.getpid()}.tmp"
+    tmp_path.write_text(rewrite_config_text(src.read_text()))
+    os.replace(tmp_path, out_path)
+    return str(out_path)
+
+
+# ── Robust prefetch into pocket_tts's download cache ────────────────────────
+#
+# ``pocket_tts.download_if_necessary`` handles plain https URLs with a bare
+# ``requests.get`` — no timeout (startup can hang forever on a stalled
+# connection), no retry, no size check and a non-atomic cache write, so a kill
+# mid-write leaves a truncated file that is treated as valid forever. To keep
+# that fragile path from ever running for our (hundreds-of-MB) R2 weights, we
+# pre-populate the exact cache entry the library will look up, with retries,
+# timeouts, size validation and an atomic rename.
+
+_PREFETCH_LOCK = threading.Lock()
+_PREFETCH_TIMEOUT = (10, 120)  # (connect, per-read) seconds
+_PREFETCH_ATTEMPTS = 3
+
+
+def _library_cache_path(url: str) -> Path:
+    """The cache file ``pocket_tts.download_if_necessary`` uses for an https URL.
+
+    Must mirror the library's logic exactly:
+    ``~/.cache/pocket_tts/<sha256(url)>.<last-dot-suffix>``. If the library ever
+    changes its layout, the worst case is a redundant download on its side —
+    never a broken load.
+    """
+    from pocket_tts.utils.utils import make_cache_directory
+
+    suffix = url.split(".")[-1]
+    return make_cache_directory() / (hashlib.sha256(url.encode()).hexdigest() + "." + suffix)
+
+
+def r2_urls_for_model(model_id: str) -> list[str]:
+    """The R2 URLs a rewritten config for ``model_id`` will reference."""
+    src = library_config_path(model_id)
+    if not src.exists():
+        return []
+    return [hf_uri_to_r2_url(u) for u in iter_gated_uris(src.read_text())]
+
+
+def _download_to_cache(url: str, cache_path: Path, log: Optional[Callable[[str], None]]) -> None:
+    """Stream ``url`` to ``cache_path`` with retries, size check and atomic rename."""
+    temp_path = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.part")
+    last_error: Optional[Exception] = None
+    delay = 2
+    for attempt in range(1, _PREFETCH_ATTEMPTS + 1):
+        try:
+            with requests.get(url, stream=True, timeout=_PREFETCH_TIMEOUT) as response:
+                response.raise_for_status()
+                total_size = int(response.headers.get("content-length", 0))
+                written = 0
+                with open(temp_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8 * 1024 * 1024):
+                        f.write(chunk)
+                        written += len(chunk)
+            if written == 0 or (total_size > 0 and written != total_size):
+                raise IOError(
+                    f"Incomplete download: got {written} of {total_size} bytes"
+                )
+            os.replace(temp_path, cache_path)
+            return
+        except Exception as e:
+            last_error = e
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            # Client errors (404 = stale mirror, 403, ...) won't heal on retry.
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status is not None and 400 <= status < 500 and status != 429:
+                break
+            if attempt < _PREFETCH_ATTEMPTS:
+                if log:
+                    log(
+                        f"Download of {url} failed (attempt {attempt}/{_PREFETCH_ATTEMPTS}): {e} — retrying in {delay}s..."
+                    )
+                time.sleep(delay)
+                delay *= 2
+    raise RuntimeError(f"Could not download {url}: {last_error}") from last_error
+
+
+def prefetch_gated_weights(
+    model_id: str, log: Optional[Callable[[str], None]] = None
+) -> None:
+    """Ensure the R2-mirrored weights for ``model_id`` are in pocket_tts's cache.
+
+    Called before ``TTSModel.load_model`` so the library finds the weights
+    already cached and never exercises its own fragile download path. No-op
+    (and no network access) when the cache is already warm, so offline starts
+    with a warm cache keep working. Raises on failure — callers decide whether
+    to surface a warning and continue (the library then falls back to the
+    public non-cloning weights).
+    """
+    for url in r2_urls_for_model(model_id):
+        cache_path = _library_cache_path(url)
+        if cache_path.exists() and cache_path.stat().st_size > 0:
+            continue
+        # One download at a time: two concurrent loads of the same model must
+        # not write the same cache entry on top of each other.
+        with _PREFETCH_LOCK:
+            if cache_path.exists() and cache_path.stat().st_size > 0:
+                continue
+            if log:
+                log(f"Downloading PocketTTS voice-cloning weights from R2 mirror: {url}")
+            _download_to_cache(url, cache_path, log)

--- a/scripts/mirror_pocket_tts_r2.py
+++ b/scripts/mirror_pocket_tts_r2.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""One-off / maintenance tool: mirror the gated PocketTTS voice-cloning weights to R2.
+
+WHY
+    The voice-cloning weights live in the *gated* ``kyutai/pocket-tts`` HF repo, which
+    needs an account that accepted the terms plus a token. End users have neither, so
+    on first start the download fails and voice cloning breaks. We host these weights
+    (unmodified) on our own Cloudflare R2 bucket - permitted by the model's CC-BY-4.0
+    license - and Wingman rewrites the configs at runtime to load them from there
+    (see providers/pocket_tts_r2.py).
+
+    Only the *gated* files are mirrored. The tokenizer and non-cloning weights are in a
+    public repo and keep downloading straight from HF, so this stays minimal.
+
+WHAT IT DOES
+    For every builtin language it reads the ``pocket_tts`` library config, finds the
+    gated ``hf://kyutai/pocket-tts/...`` URIs, downloads each from HF (using your token),
+    and uploads it to R2 at the exact key Wingman expects. Idempotent: files already
+    present in R2 are skipped unless ``--force`` is given.
+
+PREREQUISITES (what YOU need before running)
+    1. Accept the terms once at https://huggingface.co/kyutai/pocket-tts (auto-approved),
+       then authenticate locally so downloads work:
+           export HF_TOKEN=hf_xxx            # or: uvx hf auth login  /  huggingface-cli login
+    2. The AWS CLI installed (`pip install awscli`) - same tool our release CI uses.
+    3. The R2 credentials (the same GitHub secrets the release workflow uses) exported:
+           export R2_ACCOUNT_ID=...
+           export R2_ACCESS_KEY_ID=...
+           export R2_SECRET_ACCESS_KEY=...
+       Optionally override the bucket (defaults to the releases bucket):
+           export R2_BUCKET=wingman-releases
+
+USAGE
+    python scripts/mirror_pocket_tts_r2.py                 # mirror all builtin languages
+    python scripts/mirror_pocket_tts_r2.py english_2026-04 german_24l   # only these
+    python scripts/mirror_pocket_tts_r2.py --force         # re-upload even if present
+    python scripts/mirror_pocket_tts_r2.py --dry-run       # show what would happen
+"""
+
+import os
+import sys
+import shutil
+import subprocess
+from pathlib import Path
+
+# Ensure the repo root is importable when run directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from huggingface_hub import hf_hub_download  # noqa: E402
+
+from providers.pocket_tts_r2 import (  # noqa: E402
+    POCKET_TTS_R2_BASE,
+    hf_uri_to_r2_url,
+    iter_gated_uris,
+    library_config_path,
+)
+
+# Keep in sync with BUILTIN_MODELS in providers/pocket_tts.py. Hardcoded here so the
+# mirror script doesn't have to import the heavyweight provider (torch/torchaudio).
+BUILTIN_LANGUAGES = [
+    "english_2026-04",
+    "german",
+    "german_24l",
+    "french_24l",
+    "spanish",
+    "spanish_24l",
+    "italian",
+    "italian_24l",
+    "portuguese",
+    "portuguese_24l",
+]
+
+R2_BUCKET = os.environ.get("R2_BUCKET", "wingman-releases")
+# The custom domain serves the bucket root, so the S3 key is the URL path after the host.
+_R2_HOST_PREFIX = POCKET_TTS_R2_BASE.split("/models", 1)[0].rstrip("/") + "/"
+
+
+def r2_url_to_key(url: str) -> str:
+    """Turn a public R2 URL into the S3 object key inside the bucket."""
+    return url[len(_R2_HOST_PREFIX) :]
+
+
+def _r2_endpoint() -> str:
+    account = os.environ.get("R2_ACCOUNT_ID")
+    if not account:
+        sys.exit("ERROR: R2_ACCOUNT_ID is not set (see the header of this script).")
+    return f"https://{account}.r2.cloudflarestorage.com"
+
+
+def _aws_env() -> dict:
+    env = dict(os.environ)
+    # Map the R2_* names our CI uses onto what the AWS CLI expects.
+    key = os.environ.get("R2_ACCESS_KEY_ID")
+    secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if not key or not secret:
+        sys.exit("ERROR: R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are not set.")
+    env["AWS_ACCESS_KEY_ID"] = key
+    env["AWS_SECRET_ACCESS_KEY"] = secret
+    env["AWS_DEFAULT_REGION"] = "auto"
+    return env
+
+
+def _object_exists(key: str, endpoint: str, env: dict) -> bool:
+    result = subprocess.run(
+        ["aws", "s3api", "head-object", "--bucket", R2_BUCKET, "--key", key,
+         "--endpoint-url", endpoint],
+        env=env, capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+def _upload(local: str, key: str, endpoint: str, env: dict) -> None:
+    subprocess.run(
+        ["aws", "s3", "cp", local, f"s3://{R2_BUCKET}/{key}", "--endpoint-url", endpoint],
+        env=env, check=True,
+    )
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    force = "--force" in args
+    dry_run = "--dry-run" in args
+    languages = [a for a in args if not a.startswith("--")] or BUILTIN_LANGUAGES
+
+    if shutil.which("aws") is None:
+        sys.exit("ERROR: the AWS CLI is not installed. Run: pip install awscli")
+
+    endpoint = _r2_endpoint()
+    env = _aws_env()
+
+    print(f"Mirroring PocketTTS gated weights -> s3://{R2_BUCKET}/ ({endpoint})")
+    print(f"Languages: {', '.join(languages)}\n")
+
+    uploaded = skipped = 0
+    for lang in languages:
+        cfg = library_config_path(lang)
+        if not cfg.exists():
+            print(f"  [{lang}] SKIP - no bundled config at {cfg}")
+            continue
+        gated = iter_gated_uris(cfg.read_text())
+        if not gated:
+            print(f"  [{lang}] no gated files (nothing to mirror)")
+            continue
+
+        for hf_uri in gated:
+            key = r2_url_to_key(hf_uri_to_r2_url(hf_uri))
+            if not force and not dry_run and _object_exists(key, endpoint, env):
+                print(f"  [{lang}] exists, skip: {key}")
+                skipped += 1
+                continue
+            if dry_run:
+                print(f"  [{lang}] would upload: {key}\n              from: {hf_uri}")
+                continue
+
+            # hf://owner/repo/path@rev  ->  repo_id=owner/repo, filename=path, revision=rev
+            body = hf_uri[len("hf://") :]
+            body, _, revision = body.partition("@")
+            owner, repo, filename = body.split("/", 2)
+            repo_id = f"{owner}/{repo}"
+            print(f"  [{lang}] downloading {repo_id}/{filename} @ {revision[:8]} ...")
+            local = hf_hub_download(
+                repo_id=repo_id, filename=filename, revision=revision or None
+            )
+            print(f"  [{lang}] uploading -> {key}")
+            _upload(local, key, endpoint, env)
+            uploaded += 1
+
+    print(f"\nDone. uploaded={uploaded} skipped={skipped}"
+          + (" (dry run)" if dry_run else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/local_model_manager.py
+++ b/services/local_model_manager.py
@@ -1,8 +1,11 @@
 import asyncio
 import os
 import platform
+import shutil
 import stat
 import tarfile
+import threading
+import time
 import zipfile
 from os import path
 from typing import Optional
@@ -14,6 +17,19 @@ from api.interface import LlamaCppSettings
 from services.printr import Printr
 
 printr = Printr()
+
+# Retry policy for all downloads in this module — transient network failures
+# (blips, resets, mid-download aborts) must not leave the user without local AI.
+MAX_DOWNLOAD_ATTEMPTS = 3
+RETRY_BASE_DELAY_SECONDS = 2
+
+
+def _is_retryable_download_error(error: Exception) -> bool:
+    """Whether a download error is transient. 4xx (except 429) never heals on retry."""
+    status = getattr(getattr(error, "response", None), "status_code", None)
+    if status is not None and 400 <= status < 500 and status != 429:
+        return False
+    return True
 
 # Available support models — keyed by GGUF filename
 SUPPORT_MODELS: dict[str, dict] = {
@@ -89,6 +105,10 @@ class LocalModelManager:
         self.models_dir = self._get_models_dir()
         self._downloading = False
         self._download_progress: dict = {}  # {file, pct, downloaded_mb, total_mb}
+        # Serializes llama-server binary installs: download_models (executor)
+        # and _ensure_binary from load_support_model (another thread) can race
+        # for the same backend and must not extract into the same dir at once.
+        self._server_download_lock = threading.Lock()
 
     @staticmethod
     def _get_models_dir() -> str:
@@ -134,14 +154,35 @@ class LocalModelManager:
         repo = model_def["repo"]
         filename = model_def["filename"]
         target_path = path.join(self.models_dir, filename)
+        expected_size_mb = model_def.get("expected_size_mb")
 
         if path.exists(target_path):
-            printr.print(
-                f"Model already exists: {filename}",
-                color=LogType.INFO,
-                server_only=True,
-            )
-            return True
+            # Guard against a truncated file left behind by an earlier failed
+            # run: it would block re-downloading forever and only surface later
+            # as a cryptic llama-server startup failure.
+            actual_mb = os.path.getsize(target_path) // (1024 * 1024)
+            if expected_size_mb and actual_mb < expected_size_mb * 0.9:
+                printr.print(
+                    f"Existing model file looks incomplete ({actual_mb} MB, expected ~{expected_size_mb} MB) — re-downloading {filename}...",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+                try:
+                    os.remove(target_path)
+                except OSError as e:
+                    printr.print(
+                        f"Could not remove incomplete model file {target_path}: {e}",
+                        color=LogType.ERROR,
+                        server_only=True,
+                    )
+                    return False
+            else:
+                printr.print(
+                    f"Model already exists: {filename}",
+                    color=LogType.INFO,
+                    server_only=True,
+                )
+                return True
 
         url = f"https://huggingface.co/{repo}/resolve/main/{filename}"
         temp_path = target_path + ".part"
@@ -152,73 +193,92 @@ class LocalModelManager:
             server_only=True,
         )
 
-        try:
-            response = requests.get(url, stream=True, timeout=30)
-            response.raise_for_status()
+        delay = RETRY_BASE_DELAY_SECONDS
+        last_error: Optional[Exception] = None
+        for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                response = requests.get(url, stream=True, timeout=30)
+                response.raise_for_status()
 
-            total_size = int(response.headers.get("content-length", 0))
-            downloaded = 0
-            last_logged_pct = -10
-            last_callback_pct = -2
-            total_mb = total_size // (1024 * 1024) if total_size > 0 else 0
-            self._download_progress = {
-                "file": filename,
-                "pct": 0,
-                "downloaded_mb": 0,
-                "total_mb": total_mb,
-            }
+                total_size = int(response.headers.get("content-length", 0))
+                downloaded = 0
+                last_logged_pct = -10
+                last_callback_pct = -2
+                total_mb = total_size // (1024 * 1024) if total_size > 0 else 0
+                self._download_progress = {
+                    "file": filename,
+                    "pct": 0,
+                    "downloaded_mb": 0,
+                    "total_mb": total_mb,
+                }
 
-            with open(temp_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8 * 1024 * 1024):
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if total_size > 0:
-                        pct = int(downloaded / total_size * 100)
-                        downloaded_mb = downloaded // (1024 * 1024)
-                        self._download_progress = {
-                            "file": filename,
-                            "pct": pct,
-                            "downloaded_mb": downloaded_mb,
-                            "total_mb": total_mb,
-                        }
-                        if pct - last_logged_pct >= 10:
-                            printr.print(
-                                f"  {filename}: {pct}% ({downloaded_mb} MB / {total_mb} MB)",
-                                color=LogType.INFO,
-                                server_only=True,
-                            )
-                            last_logged_pct = pct
-                        if on_progress and pct - last_callback_pct >= 2:
-                            on_progress(filename, pct, downloaded_mb, total_mb)
-                            last_callback_pct = pct
+                with open(temp_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8 * 1024 * 1024):
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if total_size > 0:
+                            pct = int(downloaded / total_size * 100)
+                            downloaded_mb = downloaded // (1024 * 1024)
+                            self._download_progress = {
+                                "file": filename,
+                                "pct": pct,
+                                "downloaded_mb": downloaded_mb,
+                                "total_mb": total_mb,
+                            }
+                            if pct - last_logged_pct >= 10:
+                                printr.print(
+                                    f"  {filename}: {pct}% ({downloaded_mb} MB / {total_mb} MB)",
+                                    color=LogType.INFO,
+                                    server_only=True,
+                                )
+                                last_logged_pct = pct
+                            if on_progress and pct - last_callback_pct >= 2:
+                                on_progress(filename, pct, downloaded_mb, total_mb)
+                                last_callback_pct = pct
 
-            # Rename temp to final
-            if path.exists(target_path):
-                os.remove(target_path)
-            os.rename(temp_path, target_path)
+                # Never promote a truncated body to the final filename.
+                if downloaded == 0 or (total_size > 0 and downloaded != total_size):
+                    raise IOError(
+                        f"Incomplete download: got {downloaded} of {total_size} bytes"
+                    )
 
-            self._download_progress = {}
-            printr.print(
-                f"Download complete: {filename}",
-                color=LogType.INFO,
-                server_only=True,
-            )
-            return True
+                # Atomic rename: readers either see the old state or the
+                # complete new file, never a partial one.
+                os.replace(temp_path, target_path)
 
-        except Exception as e:
-            self._download_progress = {}
-            printr.print(
-                f"Failed to download {filename}: {e}",
-                color=LogType.ERROR,
-                server_only=True,
-            )
-            # Clean up partial download
-            if path.exists(temp_path):
-                try:
-                    os.remove(temp_path)
-                except OSError:
-                    pass
-            return False
+                self._download_progress = {}
+                printr.print(
+                    f"Download complete: {filename}",
+                    color=LogType.INFO,
+                    server_only=True,
+                )
+                return True
+
+            except Exception as e:
+                last_error = e
+                # Clean up partial download
+                if path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except OSError:
+                        pass
+                if not _is_retryable_download_error(e) or attempt >= MAX_DOWNLOAD_ATTEMPTS:
+                    break
+                printr.print(
+                    f"Download of {filename} failed (attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {e} — retrying in {delay}s...",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+                time.sleep(delay)
+                delay *= 2
+
+        self._download_progress = {}
+        printr.print(
+            f"Failed to download {filename}: {last_error}",
+            color=LogType.ERROR,
+            server_only=True,
+        )
+        return False
 
     async def download_models(
         self, cuda_available: bool = False, on_progress: callable = None
@@ -435,83 +495,141 @@ class LocalModelManager:
     def _download_llama_server(self, backend: Optional[str] = None) -> bool:
         """Download and extract the llama-server binary for a specific backend."""
         bk = backend or self._get_active_backend()
-        if self.llama_server_available(bk):
-            return True
+        with self._server_download_lock:
+            # Re-check inside the lock: another thread may have finished the
+            # install while we were waiting.
+            if self.llama_server_available(bk):
+                return True
 
-        asset_name = self._get_platform_asset_name(bk)
-        if not asset_name:
-            printr.print(
-                f"No llama-server binary available for {platform.system()} {platform.machine()} ({bk})",
-                color=LogType.ERROR,
-                server_only=True,
-            )
-            return False
-
-        url = f"https://github.com/ggml-org/llama.cpp/releases/download/{LLAMA_SERVER_VERSION}/{asset_name}"
-        server_dir = self.get_llama_server_dir(bk)
-        temp_path = path.join(self.models_dir, asset_name + ".part")
-
-        printr.print(
-            f"Downloading llama-server {LLAMA_SERVER_VERSION} ({bk}) for {platform.system()} {platform.machine()}...",
-            color=LogType.INFO,
-            server_only=True,
-        )
-
-        try:
-            self._download_and_extract(
-                url, temp_path, server_dir, f"llama-server ({bk})"
-            )
-
-            # CUDA backend on Windows also needs the CUDA runtime DLLs
-            if bk == "cuda" and platform.system() == "Windows":
-                cudart_url = f"https://github.com/ggml-org/llama.cpp/releases/download/{LLAMA_SERVER_VERSION}/{LLAMA_SERVER_CUDA_RUNTIME}"
-                cudart_temp = path.join(
-                    self.models_dir, LLAMA_SERVER_CUDA_RUNTIME + ".part"
-                )
+            asset_name = self._get_platform_asset_name(bk)
+            if not asset_name:
                 printr.print(
-                    "Downloading CUDA runtime libraries...",
-                    color=LogType.INFO,
+                    f"No llama-server binary available for {platform.system()} {platform.machine()} ({bk})",
+                    color=LogType.ERROR,
                     server_only=True,
                 )
-                self._download_and_extract(
-                    cudart_url, cudart_temp, server_dir, "CUDA runtime"
-                )
+                return False
 
-            # Make binary executable on Unix
-            binary_path = self.get_llama_server_path(bk)
-            if platform.system() != "Windows" and path.exists(binary_path):
-                os.chmod(
-                    binary_path,
-                    os.stat(binary_path).st_mode
-                    | stat.S_IEXEC
-                    | stat.S_IXGRP
-                    | stat.S_IXOTH,
-                )
+            url = f"https://github.com/ggml-org/llama.cpp/releases/download/{LLAMA_SERVER_VERSION}/{asset_name}"
+            server_dir = self.get_llama_server_dir(bk)
+            # Stage into a sibling dir and swap it in only once everything
+            # (binary + CUDA runtime DLLs) is extracted — a failure or crash
+            # mid-way can't leave a half-installed server_dir that
+            # llama_server_available() mistakes for a working install.
+            staging_dir = server_dir + ".staging"
+            temp_path = path.join(self.models_dir, asset_name + ".part")
 
             printr.print(
-                f"llama-server {LLAMA_SERVER_VERSION} ({bk}) ready.",
+                f"Downloading llama-server {LLAMA_SERVER_VERSION} ({bk}) for {platform.system()} {platform.machine()}...",
                 color=LogType.INFO,
                 server_only=True,
             )
-            return True
 
-        except Exception as e:
-            printr.print(
-                f"Failed to download llama-server ({bk}): {e}",
-                color=LogType.ERROR,
-                server_only=True,
-            )
+            try:
+                if path.isdir(staging_dir):
+                    shutil.rmtree(staging_dir)
+
+                self._download_and_extract(
+                    url, temp_path, staging_dir, f"llama-server ({bk})"
+                )
+
+                # CUDA backend on Windows also needs the CUDA runtime DLLs
+                if bk == "cuda" and platform.system() == "Windows":
+                    cudart_url = f"https://github.com/ggml-org/llama.cpp/releases/download/{LLAMA_SERVER_VERSION}/{LLAMA_SERVER_CUDA_RUNTIME}"
+                    cudart_temp = path.join(
+                        self.models_dir, LLAMA_SERVER_CUDA_RUNTIME + ".part"
+                    )
+                    printr.print(
+                        "Downloading CUDA runtime libraries...",
+                        color=LogType.INFO,
+                        server_only=True,
+                    )
+                    self._download_and_extract(
+                        cudart_url, cudart_temp, staging_dir, "CUDA runtime"
+                    )
+
+                # Everything extracted — swap the staged install into place.
+                if path.isdir(server_dir):
+                    shutil.rmtree(server_dir)
+                os.rename(staging_dir, server_dir)
+
+                # Make binary executable on Unix
+                binary_path = self.get_llama_server_path(bk)
+                if platform.system() != "Windows" and path.exists(binary_path):
+                    os.chmod(
+                        binary_path,
+                        os.stat(binary_path).st_mode
+                        | stat.S_IEXEC
+                        | stat.S_IXGRP
+                        | stat.S_IXOTH,
+                    )
+
+                printr.print(
+                    f"llama-server {LLAMA_SERVER_VERSION} ({bk}) ready.",
+                    color=LogType.INFO,
+                    server_only=True,
+                )
+                return True
+
+            except Exception as e:
+                printr.print(
+                    f"Failed to download llama-server ({bk}): {e}",
+                    color=LogType.ERROR,
+                    server_only=True,
+                )
+                if path.isdir(staging_dir):
+                    try:
+                        shutil.rmtree(staging_dir)
+                    except OSError:
+                        pass
+                return False
+
+    def _download_and_extract(
+        self, url: str, temp_path: str, target_dir: str, label: str
+    ):
+        """Download a file (with retries) and extract it into target_dir."""
+        delay = RETRY_BASE_DELAY_SECONDS
+        for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                self._stream_download_archive(url, temp_path, label)
+                break
+            except Exception as e:
+                if path.exists(temp_path):
+                    try:
+                        os.remove(temp_path)
+                    except OSError:
+                        pass
+                if (
+                    not _is_retryable_download_error(e)
+                    or attempt >= MAX_DOWNLOAD_ATTEMPTS
+                ):
+                    raise
+                printr.print(
+                    f"Download of {label} failed (attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {e} — retrying in {delay}s...",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+                time.sleep(delay)
+                delay *= 2
+
+        try:
+            # Extract archive
+            os.makedirs(target_dir, exist_ok=True)
+            archive_name = temp_path.removesuffix(".part")
+            if archive_name.endswith(".tar.gz"):
+                self._safe_extract_tar(temp_path, target_dir)
+            elif archive_name.endswith(".zip"):
+                self._safe_extract_zip(temp_path, target_dir)
+        finally:
+            # Clean up archive (also on a failed extraction — it's corrupt then)
             if path.exists(temp_path):
                 try:
                     os.remove(temp_path)
                 except OSError:
                     pass
-            return False
 
-    def _download_and_extract(
-        self, url: str, temp_path: str, target_dir: str, label: str
-    ):
-        """Download a file and extract it into target_dir."""
+    def _stream_download_archive(self, url: str, temp_path: str, label: str):
+        """Stream a single archive download to temp_path with size validation."""
         response = requests.get(url, stream=True, timeout=30, allow_redirects=True)
         response.raise_for_status()
 
@@ -546,16 +664,11 @@ class LocalModelManager:
                         )
                         last_logged_pct = pct
 
-        # Extract archive
-        os.makedirs(target_dir, exist_ok=True)
-        archive_name = temp_path.removesuffix(".part")
-        if archive_name.endswith(".tar.gz"):
-            self._safe_extract_tar(temp_path, target_dir)
-        elif archive_name.endswith(".zip"):
-            self._safe_extract_zip(temp_path, target_dir)
-
-        # Clean up archive
-        os.remove(temp_path)
+        # Never extract a truncated archive.
+        if downloaded == 0 or (total_size > 0 and downloaded != total_size):
+            raise IOError(
+                f"Incomplete download: got {downloaded} of {total_size} bytes"
+            )
 
     def download_llama_server_sync(self, backend: Optional[str] = None) -> bool:
         """Synchronous wrapper for downloading a llama-server binary."""

--- a/services/model_downloader.py
+++ b/services/model_downloader.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 from os import path
 from typing import Callable, Optional
 
@@ -9,6 +10,12 @@ from api.enums import LogType
 from services.printr import Printr
 
 printr = Printr()
+
+# Transient network failures (blips, resets, mid-download aborts) were the most
+# frequent failure source in the field — always retry with backoff before
+# surfacing an error.
+MAX_DOWNLOAD_ATTEMPTS = 3
+RETRY_BASE_DELAY_SECONDS = 2
 
 
 class ModelDownloader:
@@ -79,21 +86,61 @@ class ModelDownloader:
             server_only=True,
         )
 
+        # snapshot_download retries and resumes individual files internally, but
+        # its initial repo-info call and unlucky streaks still fail on flaky
+        # connections — retry the whole snapshot (completed files are skipped,
+        # partial files resume, so retries are cheap).
+        delay = RETRY_BASE_DELAY_SECONDS
+        last_error: Optional[Exception] = None
+        for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                result_path = await loop.run_in_executor(None, _download)
+                printr.print(
+                    f"Download complete: {repo_id}",
+                    color=LogType.POSITIVE,
+                    server_only=True,
+                )
+                return result_path
+            except Exception as e:
+                last_error = e
+                if not self._is_retryable(e) or attempt >= MAX_DOWNLOAD_ATTEMPTS:
+                    break
+                printr.print(
+                    f"Download of {repo_id} failed (attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {e} — retrying in {delay}s...",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+        printr.print(
+            f"Failed to download {repo_id}: {last_error}",
+            color=LogType.ERROR,
+            server_only=True,
+        )
+        raise last_error
+
+    @staticmethod
+    def _is_retryable(error: Exception) -> bool:
+        """Whether a download error is transient. Auth/gating/404 never heal on retry."""
         try:
-            result_path = await loop.run_in_executor(None, _download)
-            printr.print(
-                f"Download complete: {repo_id}",
-                color=LogType.POSITIVE,
-                server_only=True,
+            from huggingface_hub.errors import (
+                GatedRepoError,
+                RepositoryNotFoundError,
+                RevisionNotFoundError,
             )
-            return result_path
-        except Exception as e:
-            printr.print(
-                f"Failed to download {repo_id}: {e}",
-                color=LogType.ERROR,
-                server_only=True,
-            )
-            raise
+
+            if isinstance(
+                error,
+                (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError),
+            ):
+                return False
+        except ImportError:
+            pass
+        status = getattr(getattr(error, "response", None), "status_code", None)
+        if status is not None and 400 <= status < 500 and status != 429:
+            return False
+        return True
 
     async def download_file(
         self,
@@ -127,7 +174,10 @@ class ModelDownloader:
         loop = asyncio.get_event_loop()
 
         def _download():
-            temp_path = target_path + ".part"
+            # Unique temp name: if two triggers race the same file, they never
+            # interleave writes into the same .part; the atomic replace below
+            # makes the last writer win with a complete file either way.
+            temp_path = f"{target_path}.{os.getpid()}-{threading.get_ident()}.part"
             try:
                 response = requests.get(url, stream=True, timeout=30)
                 response.raise_for_status()
@@ -148,9 +198,13 @@ class ModelDownloader:
                                 on_progress(filename, pct, downloaded_mb, total_mb)
                                 last_callback_pct = pct
 
-                if path.exists(target_path):
-                    os.remove(target_path)
-                os.rename(temp_path, target_path)
+                # Never promote a truncated body to the final filename.
+                if downloaded == 0 or (total_size > 0 and downloaded != total_size):
+                    raise IOError(
+                        f"Incomplete download: got {downloaded} of {total_size} bytes"
+                    )
+
+                os.replace(temp_path, target_path)
                 return target_path
 
             except Exception:
@@ -167,18 +221,32 @@ class ModelDownloader:
             server_only=True,
         )
 
-        try:
-            result = await loop.run_in_executor(None, _download)
-            printr.print(
-                f"Download complete: {filename}",
-                color=LogType.POSITIVE,
-                server_only=True,
-            )
-            return result
-        except Exception as e:
-            printr.print(
-                f"Failed to download {filename}: {e}",
-                color=LogType.ERROR,
-                server_only=True,
-            )
-            raise
+        delay = RETRY_BASE_DELAY_SECONDS
+        last_error: Optional[Exception] = None
+        for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                result = await loop.run_in_executor(None, _download)
+                printr.print(
+                    f"Download complete: {filename}",
+                    color=LogType.POSITIVE,
+                    server_only=True,
+                )
+                return result
+            except Exception as e:
+                last_error = e
+                if not self._is_retryable(e) or attempt >= MAX_DOWNLOAD_ATTEMPTS:
+                    break
+                printr.print(
+                    f"Download of {filename} failed (attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {e} — retrying in {delay}s...",
+                    color=LogType.WARNING,
+                    server_only=True,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+
+        printr.print(
+            f"Failed to download {filename}: {last_error}",
+            color=LogType.ERROR,
+            server_only=True,
+        )
+        raise last_error

--- a/services/stt_provider_manager.py
+++ b/services/stt_provider_manager.py
@@ -89,6 +89,10 @@ class SttProviderManager:
         self.app_root_path = app_root_path
         self.printr = Printr()
         self.active_provider: VoiceActivationSttProvider | None = None
+        # Serializes initialize/switch_provider: a settings-triggered switch
+        # must not race the startup init (or another switch) into downloading
+        # and loading the same model twice concurrently.
+        self._init_lock = asyncio.Lock()
 
     async def initialize(
         self,
@@ -99,23 +103,24 @@ class SttProviderManager:
         Args:
             on_status: Async callback (message, progress_or_none) for UI updates.
         """
-        va_settings = self.settings_service.settings.voice_activation
-        provider = va_settings.stt_provider
+        async with self._init_lock:
+            va_settings = self.settings_service.settings.voice_activation
+            provider = va_settings.stt_provider
 
-        # Check if this is a local provider that needs download + init
-        if provider == VoiceActivationSttProvider.PARAKEET and va_settings.parakeet.run_locally:
-            await self._initialize_parakeet(on_status)
-        elif provider == VoiceActivationSttProvider.FASTER_WHISPER:
-            await self._initialize_fasterwhisper(on_status)
-        else:
-            # Remote/cloud provider — nothing to download or init
-            self.printr.print(
-                f"STT provider '{provider.value}' is remote/cloud — skipping local init.",
-                server_only=True,
-                color=LogType.INFO,
-            )
+            # Check if this is a local provider that needs download + init
+            if provider == VoiceActivationSttProvider.PARAKEET and va_settings.parakeet.run_locally:
+                await self._initialize_parakeet(on_status)
+            elif provider == VoiceActivationSttProvider.FASTER_WHISPER:
+                await self._initialize_fasterwhisper(on_status)
+            else:
+                # Remote/cloud provider — nothing to download or init
+                self.printr.print(
+                    f"STT provider '{provider.value}' is remote/cloud — skipping local init.",
+                    server_only=True,
+                    color=LogType.INFO,
+                )
 
-        self.active_provider = provider
+            self.active_provider = provider
 
     async def _initialize_parakeet(
         self,
@@ -231,22 +236,23 @@ class SttProviderManager:
         triggered switches can surface download progress via the same
         LOADING_CONFIG indicator used at startup.
         """
-        old_provider = self.active_provider
+        async with self._init_lock:
+            old_provider = self.active_provider
 
-        # Unload current provider
-        if old_provider == VoiceActivationSttProvider.PARAKEET:
-            self.parakeet.unload()
-        elif old_provider == VoiceActivationSttProvider.FASTER_WHISPER:
-            self.fasterwhisper.unload()
+            # Unload current provider
+            if old_provider == VoiceActivationSttProvider.PARAKEET:
+                self.parakeet.unload()
+            elif old_provider == VoiceActivationSttProvider.FASTER_WHISPER:
+                self.fasterwhisper.unload()
 
-        # Initialize new provider
-        va_settings = self.settings_service.settings.voice_activation
-        if new_provider == VoiceActivationSttProvider.PARAKEET and va_settings.parakeet.run_locally:
-            await self._initialize_parakeet(on_status)
-        elif new_provider == VoiceActivationSttProvider.FASTER_WHISPER:
-            await self._initialize_fasterwhisper(on_status)
+            # Initialize new provider
+            va_settings = self.settings_service.settings.voice_activation
+            if new_provider == VoiceActivationSttProvider.PARAKEET and va_settings.parakeet.run_locally:
+                await self._initialize_parakeet(on_status)
+            elif new_provider == VoiceActivationSttProvider.FASTER_WHISPER:
+                await self._initialize_fasterwhisper(on_status)
 
-        self.active_provider = new_provider
+            self.active_provider = new_provider
 
     async def _health_check_parakeet(self):
         """Run a quick transcription test on the loaded Parakeet model."""

--- a/wingman_core.py
+++ b/wingman_core.py
@@ -899,7 +899,12 @@ class WingmanCore(WebSocketUser):
                     )
                 await asyncio.sleep(0.5)
 
-            await download_task
+            if not await download_task:
+                self.printr.toast_error(
+                    "Could not download the Local AI models. "
+                    "Please check your internet connection and retry the download "
+                    "in Settings > Local AI, or restart Wingman AI."
+                )
 
         if llama_settings.run_locally and self.local_model_manager.models_available():
             await self.set_core_state(


### PR DESCRIPTION
## Linked Issue

Closes #<!-- add issue number -->

## Summary

**Fixes PocketTTS voice cloning on first start.** The voice-cloning weights live in the *gated* `kyutai/pocket-tts` HuggingFace repo, which needs an account that accepted the terms plus a token — end users have neither. On first start the download fails, `pocket_tts` silently falls back to the non-cloning weights, and any clone attempt raises `VOICE_CLONING_UNSUPPORTED`.

We now mirror **only the gated cloning `model.safetensors`** (per language) to our existing Cloudflare R2 releases bucket — permitted by the model's CC-BY-4.0 license (attribution added to the README) — and rewrite the `pocket_tts` configs at load time so gated `hf://kyutai/pocket-tts/…` URIs become `https://release.wingman-ai.com/models/…` URLs. The tokenizer and non-cloning weights are public, so they keep downloading straight from HF (no token, free, and a genuine cross-host fallback). Escape hatch for devs: `WINGMAN_POCKET_TTS_SOURCE=hf`.

The second commit **hardens model/binary downloads** across Core — these were the most frequent failure source in 3.1.3 (interrupted downloads on flaky connections leaving silent half-downloaded state).

## Changes

**PocketTTS on R2 (`pocket_tts: …`)**
- New `providers/pocket_tts_r2.py`: gated-only `hf://` → R2 URL rewrite (revision embedded in the path so a `pocket_tts` bump 404s loudly instead of serving stale weights), plus a robust `prefetch_gated_weights()` that pre-populates `pocket_tts`'s cache so its own timeout-less/retry-less download path never runs for our large weights.
- `providers/pocket_tts.py`: builtin models load via the R2 config; on prefetch failure a toast warns and the load degrades gracefully.
- New `scripts/mirror_pocket_tts_r2.py`: one-off/maintenance uploader (HF → R2, same `R2_*` creds as release CI). **Re-run when `pocket_tts` bumps model revisions.**
- `README.md`: CC-BY-4.0 attribution for the redistributed weights.

**Download robustness (`downloads: …`)**
- `services/model_downloader.py`, `services/local_model_manager.py`: retry + backoff with fast-fail on non-retryable errors (gated/404/4xx), truncation/size validation, atomic `os.replace`, corrupt-existing-file re-download, staging-dir swap for the llama-server install, and locks against concurrent downloads.
- `services/stt_provider_manager.py`: `asyncio.Lock` serializing `initialize`/`switch_provider` so a settings-triggered switch can't race startup init into a double download.
- `wingman_core.py`: user-facing toast when the startup Local AI download fails, instead of a silent AI-less state.
