### PR TITLE
migration fixes

### DIFF
--- a/services/config_manager.py
+++ b/services/config_manager.py
@@ -19,6 +19,7 @@ from api.interface import (
     NestedConfig,
     NewWingmanTemplate,
     SettingsConfig,
+    SkillConfig,
     WingmanConfig,
     WingmanConfigFileInfo,
 )
@@ -1863,7 +1864,24 @@ class ConfigManager:
                     skill_config = self.read_config(skill_default_config_path)
                     skill_config = self.__deep_merge(skill_config, skill_config_wingman)
                 else:
-                    # Custom skill without default_config.yaml - use wingman config as-is
+                    # Custom skill without default_config.yaml - the wingman
+                    # config alone is only usable if it carries the full skill
+                    # metadata itself (legacy configs did). Otherwise the skill
+                    # is not installed on this system: skip it so the wingman
+                    # still loads. The entry stays untouched in the YAML on
+                    # disk and comes back once the skill is (re)installed.
+                    try:
+                        SkillConfig(**skill_config_wingman)
+                    except ValidationError:
+                        self.printr.print(
+                            f"Custom skill '{skill_dir}' is not installed - skipping it. "
+                            f"Reinstall the skill to '{get_custom_skills_dir()}' to get it back.",
+                            color=LogType.WARNING,
+                            server_only=True,
+                            source=LogSource.SYSTEM,
+                            source_name=self.log_source_name,
+                        )
+                        continue
                     skill_config = skill_config_wingman
                     self.printr.print(
                         f"Custom skill '{skill_dir}' has no default_config.yaml, using wingman configuration only.",

--- a/services/config_manager.py
+++ b/services/config_manager.py
@@ -1029,6 +1029,38 @@ class ConfigManager:
                     stripped_skills.append(stripped_skill)
             wingman_config_dict["skills"] = stripped_skills if stripped_skills else None
 
+        # Preserve on-disk entries of skills that are not installed on this
+        # system: merge_configs skips them at load time, so a config that was
+        # loaded and saved back would silently drop them from the YAML. Skills
+        # the user deliberately removed are never affected - only installed
+        # skills show up in the UI and can be removed there.
+        existing_skills = []
+        if path.exists(config_path):
+            try:
+                existing_skills = (self.read_config(config_path) or {}).get(
+                    "skills"
+                ) or []
+            except Exception:
+                existing_skills = []
+        if existing_skills:
+            saved_modules = {
+                skill.get("module")
+                for skill in (wingman_config_dict.get("skills") or [])
+                if isinstance(skill, dict)
+            }
+            preserved_skills = [
+                entry
+                for entry in existing_skills
+                if isinstance(entry, dict)
+                and entry.get("module")
+                and entry["module"] not in saved_modules
+                and not self.find_skill_default_config_path(entry["module"])
+            ]
+            if preserved_skills:
+                wingman_config_dict["skills"] = (
+                    wingman_config_dict.get("skills") or []
+                ) + preserved_skills
+
         wingman_config_diff = self.deep_diff(default_config, wingman_config_dict)
 
         written = self.write_config(config_path, wingman_config_diff)
@@ -1766,6 +1798,39 @@ class ConfigManager:
         # Convert merged commands back to a list since that's the expected format
         return list(merged_commands.values())
 
+    @staticmethod
+    def _skill_dir_from_module(skill_module: str) -> str:
+        """Extract the skill directory name from a module path.
+
+        e.g. 'skills.vision_ai.main' -> 'vision_ai'
+        """
+        return skill_module.replace(".main", "").replace(".", "/").split("/")[-1]
+
+    def find_skill_default_config_path(self, skill_module: str) -> Optional[str]:
+        """Locate a skill's default_config.yaml, or None if the skill is not installed.
+
+        Searched in order:
+        1. Bundled skills directory (set by main.py)
+        2. Custom skills directory (non-versioned)
+        3. Legacy: versioned APPDATA skills directory
+        """
+        from services.module_manager import get_bundled_skills_dir
+
+        skill_dir = self._skill_dir_from_module(skill_module)
+
+        search_dirs = []
+        bundled_dir = get_bundled_skills_dir()
+        if bundled_dir:
+            search_dirs.append(bundled_dir)
+        search_dirs.append(get_custom_skills_dir())
+        search_dirs.append(self.skills_dir)
+
+        for base_dir in search_dirs:
+            candidate = path.join(base_dir, skill_dir, DEFAULT_SKILLS_CONFIG)
+            if path.exists(candidate):
+                return candidate
+        return None
+
     def merge_configs(self, default: Config, wingman):
         """Merge general settings with a specific wingman's overrides, including commands."""
         # Start with a copy of the wingman's specific config to keep it intact.
@@ -1816,49 +1881,12 @@ class ConfigManager:
         if "skills" in wingman:
             merged_skills = []
             for skill_config_wingman in wingman["skills"]:
-                skill_dir = (
+                skill_dir = self._skill_dir_from_module(
                     skill_config_wingman["module"]
-                    .replace(".main", "")
-                    .replace(".", "/")
-                    .split("/")[1]
                 )
-
-                # Look for skill default_config.yaml in multiple locations:
-                # 1. Bundled skills directory (set by main.py)
-                # 2. Custom skills directory (non-versioned)
-                # 3. Legacy: versioned APPDATA skills directory
-                from services.module_manager import get_bundled_skills_dir
-
-                skill_default_config_path = None
-                search_paths = []
-
-                # 1. Bundled skills
-                bundled_dir = get_bundled_skills_dir()
-                if bundled_dir:
-                    bundled_path = path.join(
-                        bundled_dir, skill_dir, DEFAULT_SKILLS_CONFIG
-                    )
-                    search_paths.append(bundled_path)
-                    if path.exists(bundled_path):
-                        skill_default_config_path = bundled_path
-
-                # 2. Custom skills (non-versioned)
-                if not skill_default_config_path:
-                    custom_path = path.join(
-                        get_custom_skills_dir(), skill_dir, DEFAULT_SKILLS_CONFIG
-                    )
-                    search_paths.append(custom_path)
-                    if path.exists(custom_path):
-                        skill_default_config_path = custom_path
-
-                # 3. Legacy: versioned APPDATA (for migration compatibility)
-                if not skill_default_config_path:
-                    legacy_path = path.join(
-                        self.skills_dir, skill_dir, DEFAULT_SKILLS_CONFIG
-                    )
-                    search_paths.append(legacy_path)
-                    if path.exists(legacy_path):
-                        skill_default_config_path = legacy_path
+                skill_default_config_path = self.find_skill_default_config_path(
+                    skill_config_wingman["module"]
+                )
 
                 if skill_default_config_path:
                     skill_config = self.read_config(skill_default_config_path)

--- a/services/config_migration_service.py
+++ b/services/config_migration_service.py
@@ -731,6 +731,11 @@ class ConfigMigrationService:
         validation and silently reset the user's whole file to the shipped
         template. With the template as the base, every current field exists
         while migrated user values always win.
+
+        INVARIANT: a key that a migration hook deliberately deletes must also
+        be absent from the template, otherwise this merge resurrects it with
+        the template value. Holds for all current hooks; keep it that way when
+        deprecating fields.
         """
         template_file = path.join(self.templates_dir, CONFIGS_DIR, template_filename)
         if not path.exists(template_file):
@@ -985,8 +990,11 @@ class ConfigMigrationService:
                 # defaults
                 elif filename == "defaults.yaml":
                     self.log_highlight("Migrating defaults.yaml...")
-                    migrated_defaults = migrate_defaults(
-                        old=self.config_manager.read_config(old_file),
+                    migrated_defaults = (
+                        migrate_defaults(
+                            old=self.config_manager.read_config(old_file),
+                        )
+                        or {}
                     )
                     try:
                         # Only validate on final migration step (current schema may not match intermediate versions)

--- a/services/config_migration_service.py
+++ b/services/config_migration_service.py
@@ -708,6 +708,38 @@ class ConfigMigrationService:
 
         return {}
 
+    def _deep_merge_over(self, base: dict, override: dict) -> dict:
+        """Recursively merge ``override`` into ``base``; override values win."""
+        merged = dict(base)
+        for key, value in override.items():
+            if (
+                key in merged
+                and isinstance(merged[key], dict)
+                and isinstance(value, dict)
+            ):
+                merged[key] = self._deep_merge_over(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+
+    def backfill_from_template(self, template_filename: str, migrated: dict) -> dict:
+        """Deep-merge a migrated config over its current template.
+
+        Migration hooks only transform what they know about. A field that
+        became required in the models without a matching hook (hud_server,
+        pocket_tts, condense_max_messages, ...) would fail the final
+        validation and silently reset the user's whole file to the shipped
+        template. With the template as the base, every current field exists
+        while migrated user values always win.
+        """
+        template_file = path.join(self.templates_dir, CONFIGS_DIR, template_filename)
+        if not path.exists(template_file):
+            return migrated
+        template = self.config_manager.read_config(template_file) or {}
+        if not isinstance(template, dict):
+            return migrated
+        return self._deep_merge_over(template, migrated or {})
+
     def log(self, message: str):
         """Log a normal message."""
         self._log_with_color(message, LogType.SYSTEM)
@@ -925,15 +957,29 @@ class ConfigMigrationService:
                 # settings
                 elif filename == "settings.yaml":
                     self.log_highlight("Migrating settings.yaml...")
-                    migrated_settings = migrate_settings(
-                        old=self.config_manager.read_config(old_file),
+                    migrated_settings = (
+                        migrate_settings(
+                            old=self.config_manager.read_config(old_file),
+                        )
+                        or {}
                     )
                     try:
+                        # Only validate on final migration step (current schema may not match intermediate versions)
                         if new_config_path == self.latest_config_path:
+                            migrated_settings = self.backfill_from_template(
+                                "settings.yaml", migrated_settings
+                            )
                             self.config_manager.settings_config = SettingsConfig(
                                 **migrated_settings
                             )
-                        self.config_manager.save_settings_config()
+                            self.config_manager.save_settings_config()
+                        else:
+                            # Intermediate step - persist the migrated file so the
+                            # next chain step continues from it instead of the
+                            # untouched copy of the old version's file.
+                            self.config_manager.write_config(
+                                new_file, migrated_settings
+                            )
                     except ValidationError as e:
                         self.err(f"Unable to migrate settings.yaml:\n{str(e)}")
                 # defaults
@@ -945,6 +991,9 @@ class ConfigMigrationService:
                     try:
                         # Only validate on final migration step (current schema may not match intermediate versions)
                         if new_config_path == self.latest_config_path:
+                            migrated_defaults = self.backfill_from_template(
+                                "defaults.yaml", migrated_defaults
+                            )
                             self.config_manager.default_config = NestedConfig(
                                 **migrated_defaults
                             )

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -296,9 +296,12 @@ class SettingsService:
         # save the config file
         self.config_manager.save_settings_config()
 
-        # update running wingmen
-        for wingman in self.config_service.tower.wingmen:
-            await wingman.update_settings(settings=self.config_manager.settings_config)
+        # update running wingmen (tower is None while a config (re)loads or failed to load)
+        if self.config_service.tower:
+            for wingman in self.config_service.tower.wingmen:
+                await wingman.update_settings(
+                    settings=self.config_manager.settings_config
+                )
 
     def save_settings_to_disk(self):
         """Persist current settings to disk without triggering provider updates."""


### PR DESCRIPTION
Fixes several problems reported by a tester who updated from Wingman AI 2.1.1 to 3.1.6:

- **Updating from an old version could wipe your settings.** When the update had to
  jump across several versions at once, changes got lost along the way and Wingman AI
  silently fell back to factory settings — audio devices, voice activation, STT
  configuration, everything. Updates now carry all your settings over correctly, no
  matter how old the version you're coming from is.
- **A single missing custom skill blocked a whole config.** If one of your Wingmen
  used a custom skill that isn't installed on your PC (anymore), the entire config
  refused to load. Now the missing skill is simply skipped with a warning and
  everything else keeps working. Your settings for that skill are kept, so it comes
  back as soon as you reinstall it.
- **Saving settings could fail with an error** while Wingman AI was still starting up
  or when no config was loaded.

Also fixed in the Client (ships with the same release): the on/off switches for
**whispercpp, XVASynth and persistent memory** looked enabled but were never actually
saved — which is why whispercpp kept turning itself off even after a successful
connection test.

If this bug already reset your settings: update, close Wingman AI, delete everything `> 2.1.1 ` in `%APPDATA%\ShipBit\WingmanAI`, and start again — the update will
re-run and restore everything from your old version.